### PR TITLE
Adopt typed throws across 'BinaryParsing'

### DIFF
--- a/Sources/BinaryParsing/Macros/MagicNumber.swift
+++ b/Sources/BinaryParsing/Macros/MagicNumber.swift
@@ -15,7 +15,7 @@ func _loadAndCheckDirectBytes<
 >(
   parsing input: inout ParserSpan,
   bigEndianValue: T
-) throws {
+) throws(ParsingError) {
   let loadedValue = try T(parsingBigEndian: &input)
   guard loadedValue == bigEndianValue else {
     throw ParsingError(
@@ -29,7 +29,7 @@ func _loadAndCheckDirectBytesByteOrder<
 >(
   parsing input: inout ParserSpan,
   bigEndianValue: T
-) throws -> Endianness {
+) throws(ParsingError) -> Endianness {
   let loadedValue = try T(parsingBigEndian: &input)
   if loadedValue == bigEndianValue {
     return .big

--- a/Sources/BinaryParsing/Operations/Optionators.swift
+++ b/Sources/BinaryParsing/Operations/Optionators.swift
@@ -108,7 +108,7 @@ extension Optional where Wrapped: Comparable {
     guard lhs <= rhs else { return nil }
     return lhs..<rhs
   }
-  
+
   @inlinable @inline(__always)
   public static func ...? (lhs: Self, rhs: Self) -> ClosedRange<Wrapped>? {
     guard let lhs, let rhs else { return nil }

--- a/Sources/BinaryParsing/Operations/ThrowingOperations.swift
+++ b/Sources/BinaryParsing/Operations/ThrowingOperations.swift
@@ -12,7 +12,7 @@
 extension Collection {
   @inlinable
   public subscript(throwing i: Index) -> Element {
-    get throws {
+    get throws(ParsingError) {
       guard (startIndex..<endIndex).contains(i) else {
         throw ParsingError(statusOnly: .invalidValue)
       }
@@ -24,7 +24,7 @@ extension Collection {
 extension Optional {
   @inlinable
   public var unwrapped: Wrapped {
-    get throws {
+    get throws(ParsingError) {
       switch self {
       case .some(let v): return v
       case .none:
@@ -36,7 +36,8 @@ extension Optional {
 
 extension BinaryInteger {
   @inlinable
-  public init(throwingOnOverflow other: some BinaryInteger) throws {
+  public init(throwingOnOverflow other: some BinaryInteger) throws(ParsingError)
+  {
     guard let newValue = Self(exactly: other) else {
       throw ParsingError(statusOnly: .invalidValue)
     }
@@ -48,7 +49,9 @@ extension FixedWidthInteger {
   // MARK: Nonmutating arithmetic
 
   @inlinable
-  public func addingThrowingOnOverflow(_ other: Self) throws -> Self {
+  public func addingThrowingOnOverflow(_ other: Self) throws(ParsingError)
+    -> Self
+  {
     let (result, overflow) = addingReportingOverflow(other)
     if overflow {
       throw ParsingError(statusOnly: .invalidValue)
@@ -57,7 +60,9 @@ extension FixedWidthInteger {
   }
 
   @inlinable
-  public func subtractingThrowingOnOverflow(_ other: Self) throws -> Self {
+  public func subtractingThrowingOnOverflow(_ other: Self) throws(ParsingError)
+    -> Self
+  {
     let (result, overflow) = subtractingReportingOverflow(other)
     if overflow {
       throw ParsingError(statusOnly: .invalidValue)
@@ -66,7 +71,9 @@ extension FixedWidthInteger {
   }
 
   @inlinable
-  public func multipliedThrowingOnOverflow(by other: Self) throws -> Self {
+  public func multipliedThrowingOnOverflow(by other: Self) throws(ParsingError)
+    -> Self
+  {
     let (result, overflow) = multipliedReportingOverflow(by: other)
     if overflow {
       throw ParsingError(statusOnly: .invalidValue)
@@ -75,7 +82,9 @@ extension FixedWidthInteger {
   }
 
   @inlinable
-  public func dividedThrowingOnOverflow(by other: Self) throws -> Self {
+  public func dividedThrowingOnOverflow(by other: Self) throws(ParsingError)
+    -> Self
+  {
     let (result, overflow) = dividedReportingOverflow(by: other)
     if overflow {
       throw ParsingError(statusOnly: .invalidValue)
@@ -84,7 +93,8 @@ extension FixedWidthInteger {
   }
 
   @inlinable
-  public func remainderThrowingOnOverflow(dividingBy other: Self) throws -> Self
+  public func remainderThrowingOnOverflow(dividingBy other: Self)
+    throws(ParsingError) -> Self
   {
     let (result, overflow) = remainderReportingOverflow(dividingBy: other)
     if overflow {
@@ -96,28 +106,35 @@ extension FixedWidthInteger {
   // MARK: Mutating arithmetic
 
   @inlinable
-  public mutating func addThrowingOnOverflow(_ other: Self) throws {
+  public mutating func addThrowingOnOverflow(_ other: Self) throws(ParsingError)
+  {
     self = try self.addingThrowingOnOverflow(other)
   }
 
   @inlinable
-  public mutating func subtractThrowingOnOverflow(_ other: Self) throws {
+  public mutating func subtractThrowingOnOverflow(_ other: Self)
+    throws(ParsingError)
+  {
     self = try self.subtractingThrowingOnOverflow(other)
   }
 
   @inlinable
-  public mutating func multiplyThrowingOnOverflow(by other: Self) throws {
+  public mutating func multiplyThrowingOnOverflow(by other: Self)
+    throws(ParsingError)
+  {
     self = try self.multipliedThrowingOnOverflow(by: other)
   }
 
   @inlinable
-  public mutating func divideThrowingOnOverflow(by other: Self) throws {
+  public mutating func divideThrowingOnOverflow(by other: Self)
+    throws(ParsingError)
+  {
     self = try self.dividedThrowingOnOverflow(by: other)
   }
 
   @inlinable
   public mutating func formRemainderThrowingOnOverflow(dividingBy other: Self)
-    throws
+    throws(ParsingError)
   {
     self = try self.remainderThrowingOnOverflow(dividingBy: other)
   }

--- a/Sources/BinaryParsing/Parser Types/ParserRange.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserRange.swift
@@ -35,7 +35,8 @@ public struct ParserRange: Hashable {
 }
 
 extension ParserRange {
-  public func slicing<C: Collection<UInt8>>(_ coll: C) throws -> C.SubSequence
+  public func slicing<C: Collection<UInt8>>(_ coll: C) throws(ParsingError)
+    -> C.SubSequence
   where C.Index == Int {
     let validRange = coll.startIndex...coll.endIndex
     guard validRange.contains(range.lowerBound),
@@ -49,7 +50,7 @@ extension ParserRange {
 
 extension RandomAccessCollection<UInt8> where Index == Int {
   public subscript(_ range: ParserRange) -> SubSequence {
-    get throws {
+    get throws(ParsingError) {
       let validRange = startIndex...endIndex
       guard validRange.contains(range.lowerBound),
         validRange.contains(range.upperBound)

--- a/Sources/BinaryParsing/Parser Types/ParserSource.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSource.swift
@@ -15,20 +15,20 @@ public import Foundation
 
 public protocol ExpressibleByParsing {
   @lifetime(&input)
-  init(parsing input: inout ParserSpan) throws
+  init(parsing input: inout ParserSpan) throws(ThrownParsingError)
 }
 
 extension ExpressibleByParsing {
-  public init(parsing data: some RandomAccessCollection<UInt8>) throws {
+  public init(parsing data: some RandomAccessCollection<UInt8>)
+    throws(ThrownParsingError)
+  {
     guard
-      let result = try data.withParserSpanIfAvailable({ span in
+      let result = try data.withParserSpanIfAvailable({
+        (span) throws(ThrownParsingError) in
         try Self.init(parsing: &span)
       })
     else {
-      throw ParsingError(
-        status: .invalidValue,
-        location: 0,
-        message: "Provided data type does not support contiguous access.")
+      throw ParsingError(statusOnly: .invalidValue)
     }
     self = result
   }
@@ -37,20 +37,32 @@ extension ExpressibleByParsing {
 extension RandomAccessCollection<UInt8> {
   @inlinable
   public func withParserSpanIfAvailable<T>(
-    _ body: (inout ParserSpan) throws -> T
-  ) throws -> T? {
+    _ body: (inout ParserSpan) throws(ThrownParsingError) -> T
+  ) throws(ThrownParsingError) -> T? {
     #if canImport(Foundation)
     if let data = self as? Foundation.Data {
-      return try data.withUnsafeBytes { buffer -> T in
-        var span = ParserSpan(_unsafeBytes: buffer)
-        return try body(&span)
+      do {
+        return try data.withUnsafeBytes { buffer -> T in
+          var span = ParserSpan(_unsafeBytes: buffer)
+          return try body(&span)
+        }
+      } catch {
+        // Workaround for lack of typed-throwing API on Data
+        // swift-format-ignore: NeverForceUnwrap
+        throw error as! ThrownParsingError
       }
     }
     #endif
-    return try self.withContiguousStorageIfAvailable { buffer in
-      let rawBuffer = UnsafeRawBufferPointer(buffer)
-      var span = ParserSpan(_unsafeBytes: rawBuffer)
-      return try body(&span)
+    do {
+      return try self.withContiguousStorageIfAvailable { buffer in
+        let rawBuffer = UnsafeRawBufferPointer(buffer)
+        var span = ParserSpan(_unsafeBytes: rawBuffer)
+        return try body(&span)
+      }
+    } catch {
+      // Workaround for lack of typed-throwing API on Collection
+      // swift-format-ignore: NeverForceUnwrap
+      throw error as! ThrownParsingError
     }
   }
 }
@@ -58,20 +70,28 @@ extension RandomAccessCollection<UInt8> {
 // MARK: ParserSpanProvider
 
 public protocol ParserSpanProvider {
-  func withParserSpan<T>(_ body: (inout ParserSpan) throws -> T) throws -> T
+  func withParserSpan<T>(
+    _ body: (inout ParserSpan) throws(ThrownParsingError) -> T
+  ) throws(ThrownParsingError) -> T
 }
 
 #if canImport(Foundation)
 extension Data: ParserSpanProvider {
   @inlinable
-  public func withParserSpan<T>(_ body: (inout ParserSpan) throws -> T) throws
-    -> T
-  {
-    try withUnsafeBytes { buffer -> T in
-      // FIXME: RawSpan getter
-      //      var span = ParserSpan(buffer.bytes)
-      var span = ParserSpan(_unsafeBytes: buffer)
-      return try body(&span)
+  public func withParserSpan<T>(
+    _ body: (inout ParserSpan) throws(ThrownParsingError) -> T
+  ) throws(ThrownParsingError) -> T {
+    do {
+      return try withUnsafeBytes { buffer -> T in
+        // FIXME: RawSpan getter
+        //      var span = ParserSpan(buffer.bytes)
+        var span = ParserSpan(_unsafeBytes: buffer)
+        return try body(&span)
+      }
+    } catch {
+      // Workaround for lack of typed-throwing API on Data
+      // swift-format-ignore: NeverForceUnwrap
+      throw error as! ThrownParsingError
     }
   }
 
@@ -79,17 +99,23 @@ extension Data: ParserSpanProvider {
   @inlinable
   public func withParserSpan<T>(
     usingRange range: inout ParserRange,
-    _ body: (inout ParserSpan) throws -> T
-  ) rethrows -> T {
-    try withUnsafeBytes { buffer -> T in
-      // FIXME: RawSpan getter
-      //      var span = try ParserSpan(buffer.bytes)
-      var span = try ParserSpan(_unsafeBytes: buffer)
-        .seeking(toRange: range)
-      defer {
-        range = span.parserRange
+    _ body: (inout ParserSpan) throws(ThrownParsingError) -> T
+  ) throws(ThrownParsingError) -> T {
+    do {
+      return try withUnsafeBytes { (buffer) throws(ThrownParsingError) -> T in
+        // FIXME: RawSpan getter
+        //      var span = try ParserSpan(buffer.bytes)
+        var span = try ParserSpan(_unsafeBytes: buffer)
+          .seeking(toRange: range)
+        defer {
+          range = span.parserRange
+        }
+        return try body(&span)
       }
-      return try body(&span)
+    } catch {
+      // Workaround for lack of typed-throwing API on Data
+      // swift-format-ignore: NeverForceUnwrap
+      throw error as! ThrownParsingError
     }
   }
 }
@@ -97,21 +123,27 @@ extension Data: ParserSpanProvider {
 
 extension ParserSpanProvider where Self: RandomAccessCollection<UInt8> {
   @inlinable
-  public func withParserSpan<T>(_ body: (inout ParserSpan) throws -> T) throws
-    -> T
-  {
-    guard
-      let result = try self.withContiguousStorageIfAvailable({ buffer in
-        // FIXME: RawSpan getter
-        //      var span = ParserSpan(UnsafeRawBufferPointer(buffer).bytes)
-        let rawBuffer = UnsafeRawBufferPointer(buffer)
-        var span = ParserSpan(_unsafeBytes: rawBuffer)
-        return try body(&span)
-      })
-    else {
-      throw ParsingError(status: .userError, location: 0)
+  public func withParserSpan<T>(
+    _ body: (inout ParserSpan) throws(ThrownParsingError) -> T
+  ) throws(ThrownParsingError) -> T {
+    do {
+      guard
+        let result = try self.withContiguousStorageIfAvailable({ buffer in
+          // FIXME: RawSpan getter
+          //      var span = ParserSpan(UnsafeRawBufferPointer(buffer).bytes)
+          let rawBuffer = UnsafeRawBufferPointer(buffer)
+          var span = ParserSpan(_unsafeBytes: rawBuffer)
+          return try body(&span)
+        })
+      else {
+        throw ParsingError(status: .userError, location: 0)
+      }
+      return result
+    } catch {
+      // Workaround for lack of typed-throwing API on Collection
+      // swift-format-ignore: NeverForceUnwrap
+      throw error as! ThrownParsingError
     }
-    return result
   }
 }
 

--- a/Sources/BinaryParsing/Parser Types/ParserSpan.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSpan.swift
@@ -121,10 +121,10 @@ extension ParserSpan {
   @_alwaysEmitIntoClient
   @inlinable
   @unsafe
-  public func withUnsafeBytes<T>(
-    _ body: (UnsafeRawBufferPointer) throws -> T
-  ) rethrows -> T {
-    try _bytes.withUnsafeBytes { fullBuffer in
+  public func withUnsafeBytes<T, E>(
+    _ body: (UnsafeRawBufferPointer) throws(E) -> T
+  ) throws(E) -> T {
+    try _bytes.withUnsafeBytes { (fullBuffer) throws(E) in
       let buffer = UnsafeRawBufferPointer(
         rebasing: fullBuffer[_lowerBound..<_upperBound])
       return try body(buffer)
@@ -137,7 +137,7 @@ extension ParserSpan {
   @usableFromInline
   internal mutating func _divide(
     atByteOffset count: some FixedWidthInteger
-  ) throws -> ParserSpan {
+  ) throws(ParsingError) -> ParserSpan {
     guard let count = Int(exactly: count), count >= 0 else {
       throw ParsingError(status: .invalidValue, location: startPosition)
     }
@@ -186,9 +186,9 @@ extension ParserSpan {
   /// `atomically` guarantees that the input span isn't modified in that case.
   @inlinable
   @lifetime(&self)
-  public mutating func atomically<T>(_ body: (inout ParserSpan) throws -> T)
-    rethrows -> T
-  {
+  public mutating func atomically<T, E>(
+    _ body: (inout ParserSpan) throws(E) -> T
+  ) throws(E) -> T {
     // Make a mutable copy to perform the work in `body`.
     var copy = self
     let result = try body(&copy)

--- a/Sources/BinaryParsing/Parser Types/ParsingError.swift
+++ b/Sources/BinaryParsing/Parser Types/ParsingError.swift
@@ -107,3 +107,9 @@ extension ParsingError: CustomStringConvertible {
   }
 }
 #endif
+
+#if !$Embedded
+public typealias ThrownParsingError = any Error
+#else
+public typealias ThrownParsingError = ParsingError
+#endif

--- a/Sources/BinaryParsing/Parser Types/Seeking.swift
+++ b/Sources/BinaryParsing/Parser Types/Seeking.swift
@@ -12,7 +12,9 @@
 extension ParserSpan {
   @inlinable
   @lifetime(copy self)
-  public func seeking(toRange range: ParserRange) throws -> ParserSpan {
+  public func seeking(toRange range: ParserRange)
+    throws(ParsingError) -> ParserSpan
+  {
     var result = self
     try result.seek(toRange: range)
     return result
@@ -20,8 +22,8 @@ extension ParserSpan {
 
   @inlinable
   @lifetime(copy self)
-  public func seeking(toRelativeOffset offset: some FixedWidthInteger) throws
-    -> ParserSpan
+  public func seeking(toRelativeOffset offset: some FixedWidthInteger)
+    throws(ParsingError) -> ParserSpan
   {
     var result = self
     try result.seek(toRelativeOffset: offset)
@@ -30,8 +32,8 @@ extension ParserSpan {
 
   @inlinable
   @lifetime(copy self)
-  public func seeking(toAbsoluteOffset offset: some FixedWidthInteger) throws
-    -> ParserSpan
+  public func seeking(toAbsoluteOffset offset: some FixedWidthInteger)
+    throws(ParsingError) -> ParserSpan
   {
     var result = self
     try result.seek(toAbsoluteOffset: offset)
@@ -40,8 +42,8 @@ extension ParserSpan {
 
   @inlinable
   @lifetime(copy self)
-  public func seeking(toOffsetFromEnd offset: some FixedWidthInteger) throws
-    -> ParserSpan
+  public func seeking(toOffsetFromEnd offset: some FixedWidthInteger)
+    throws(ParsingError) -> ParserSpan
   {
     var result = self
     try result.seek(toOffsetFromEnd: offset)
@@ -52,7 +54,7 @@ extension ParserSpan {
 extension ParserSpan {
   @inlinable
   @lifetime(&self)
-  public mutating func seek(toRange range: ParserRange) throws {
+  public mutating func seek(toRange range: ParserRange) throws(ParsingError) {
     guard (0..._bytes.byteCount).contains(range.lowerBound),
       (0..._bytes.byteCount).contains(range.upperBound)
     else {
@@ -65,7 +67,7 @@ extension ParserSpan {
   @inlinable
   @lifetime(&self)
   public mutating func seek(toRelativeOffset offset: some FixedWidthInteger)
-    throws
+    throws(ParsingError)
   {
     guard let offset = Int(exactly: offset),
       (-startPosition...count).contains(offset)
@@ -78,7 +80,7 @@ extension ParserSpan {
   @inlinable
   @lifetime(&self)
   public mutating func seek(toAbsoluteOffset offset: some FixedWidthInteger)
-    throws
+    throws(ParsingError)
   {
     guard let offset = Int(exactly: offset),
       (0..._bytes.byteCount).contains(offset)
@@ -92,7 +94,7 @@ extension ParserSpan {
   @inlinable
   @lifetime(&self)
   public mutating func seek(toOffsetFromEnd offset: some FixedWidthInteger)
-    throws
+    throws(ParsingError)
   {
     guard let offset = Int(exactly: offset),
       (0..._bytes.byteCount).contains(offset)

--- a/Sources/BinaryParsing/Parser Types/Slicing.swift
+++ b/Sources/BinaryParsing/Parser Types/Slicing.swift
@@ -12,8 +12,8 @@
 extension ParserSpan {
   @inlinable
   @lifetime(copy self)
-  public mutating func sliceSpan(byteCount: some FixedWidthInteger) throws
-    -> ParserSpan
+  public mutating func sliceSpan(byteCount: some FixedWidthInteger)
+    throws(ParsingError) -> ParserSpan
   {
     guard let byteCount = Int(exactly: byteCount), count >= 0 else {
       throw ParsingError(status: .invalidValue, location: startPosition)
@@ -29,7 +29,7 @@ extension ParserSpan {
   public mutating func sliceSpan(
     objectStride: some FixedWidthInteger,
     objectCount: some FixedWidthInteger
-  ) throws -> ParserSpan {
+  ) throws(ParsingError) -> ParserSpan {
     guard let objectCount = Int(exactly: objectCount),
       let objectStride = Int(exactly: objectStride),
       let byteCount = objectCount *? objectStride,
@@ -45,8 +45,8 @@ extension ParserSpan {
 extension ParserSpan {
   @inlinable
   @lifetime(&self)
-  public mutating func sliceRange(byteCount: some FixedWidthInteger) throws
-    -> ParserRange
+  public mutating func sliceRange(byteCount: some FixedWidthInteger)
+    throws(ParsingError) -> ParserRange
   {
     try sliceSpan(byteCount: byteCount).parserRange
   }
@@ -56,7 +56,7 @@ extension ParserSpan {
   public mutating func sliceRange(
     objectStride: some FixedWidthInteger,
     objectCount: some FixedWidthInteger
-  ) throws -> ParserRange {
+  ) throws(ParsingError) -> ParserRange {
     try sliceSpan(objectStride: objectStride, objectCount: objectCount)
       .parserRange
   }
@@ -66,10 +66,14 @@ extension ParserSpan {
   @inlinable
   @lifetime(copy self)
   @available(macOS 9999, *)
-  public mutating func sliceUTF8Span(byteCount: some FixedWidthInteger) throws
-    -> UTF8Span
+  public mutating func sliceUTF8Span(byteCount: some FixedWidthInteger)
+    throws(ParsingError) -> UTF8Span
   {
     let rawSpan = try sliceSpan(byteCount: byteCount).bytes
-    return try UTF8Span(validating: Span<UInt8>(_bytes: rawSpan))
+    do {
+      return try UTF8Span(validating: Span<UInt8>(_bytes: rawSpan))
+    } catch {
+      throw ParsingError(status: .userError, location: startPosition)
+    }
   }
 }

--- a/Sources/BinaryParsing/Parsers/Range.swift
+++ b/Sources/BinaryParsing/Parsers/Range.swift
@@ -15,8 +15,8 @@ extension Range where Bound: FixedWidthInteger {
   @lifetime(&input)
   public init(
     parsingStartAndCount input: inout ParserSpan,
-    parser: (inout ParserSpan) throws -> Bound
-  ) throws {
+    parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
+  ) throws(ThrownParsingError) {
     let start = try parser(&input)
     let count = try parser(&input)
     guard count >= 0, let end = start +? count else {
@@ -37,8 +37,8 @@ extension ClosedRange where Bound: FixedWidthInteger {
   @lifetime(&input)
   public init(
     parsingStartAndCount input: inout ParserSpan,
-    parser: (inout ParserSpan) throws -> Bound
-  ) throws {
+    parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
+  ) throws(ThrownParsingError) {
     let start = try parser(&input)
     let count = try parser(&input)
     guard count > 0, let end = start +? count -? 1 else {
@@ -56,8 +56,8 @@ extension Range {
   @lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
-    boundsParser parser: (inout ParserSpan) throws -> Bound
-  ) throws {
+    boundsParser parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
+  ) throws(ThrownParsingError) {
     let start = try parser(&input)
     let end = try parser(&input)
     guard start <= end else {
@@ -73,8 +73,8 @@ extension ClosedRange {
   @lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
-    boundsParser parser: (inout ParserSpan) throws -> Bound
-  ) throws {
+    boundsParser parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
+  ) throws(ThrownParsingError) {
     let start = try parser(&input)
     let end = try parser(&input)
     guard start <= end else {

--- a/Sources/BinaryParsing/Parsers/String.swift
+++ b/Sources/BinaryParsing/Parsers/String.swift
@@ -12,7 +12,8 @@
 extension String {
   @inlinable
   @lifetime(&input)
-  public init(parsingNulTerminated input: inout ParserSpan) throws {
+  public init(parsingNulTerminated input: inout ParserSpan) throws(ParsingError)
+  {
     guard
       let nulOffset = input.withUnsafeBytes({ buffer in
         buffer.firstIndex(of: 0)
@@ -26,7 +27,7 @@ extension String {
 
   @inlinable
   @lifetime(&input)
-  public init(parsingUTF8 input: inout ParserSpan) throws {
+  public init(parsingUTF8 input: inout ParserSpan) throws(ParsingError) {
     let stringBytes = input.divide(at: input.endPosition)
     self = stringBytes.withUnsafeBytes { buffer in
       String(decoding: buffer, as: UTF8.self)
@@ -35,14 +36,18 @@ extension String {
 
   @inlinable
   @lifetime(&input)
-  public init(parsingUTF8 input: inout ParserSpan, count: Int) throws {
+  public init(parsingUTF8 input: inout ParserSpan, count: Int)
+    throws(ParsingError)
+  {
     var slice = try input._divide(atByteOffset: count)
     try self.init(parsingUTF8: &slice)
   }
 
   @inlinable
   @lifetime(&input)
-  internal init(_uncheckedParsingUTF16 input: inout ParserSpan) throws {
+  internal init(_uncheckedParsingUTF16 input: inout ParserSpan)
+    throws(ParsingError)
+  {
     let stringBytes = input.divide(at: input.endPosition)
     self = stringBytes.withUnsafeBytes { buffer in
       let utf16Buffer = buffer.assumingMemoryBound(to: UInt16.self)
@@ -52,7 +57,7 @@ extension String {
 
   @inlinable
   @lifetime(&input)
-  public init(parsingUTF16 input: inout ParserSpan) throws {
+  public init(parsingUTF16 input: inout ParserSpan) throws(ParsingError) {
     guard input.count.isMultiple(of: 2) else {
       throw ParsingError(status: .invalidValue, location: input.startPosition)
     }
@@ -61,7 +66,9 @@ extension String {
 
   @inlinable
   @lifetime(&input)
-  public init(parsingUTF16 input: inout ParserSpan, codeUnitCount: Int) throws {
+  public init(parsingUTF16 input: inout ParserSpan, codeUnitCount: Int)
+    throws(ParsingError)
+  {
     var slice = try input._divide(
       atByteOffset: codeUnitCount.multipliedThrowingOnOverflow(by: 2))
     try self.init(_uncheckedParsingUTF16: &slice)

--- a/Tests/BinaryParsingTests/OptionatorTests.swift
+++ b/Tests/BinaryParsingTests/OptionatorTests.swift
@@ -21,7 +21,7 @@ struct OptionatorTests {
     let actualInfix = a +? b
     var actualAssign = a
     actualAssign +?= b
-    
+
     switch expected {
     case (let result, false)?:
       #expect(actualInfix == result)
@@ -31,14 +31,14 @@ struct OptionatorTests {
       #expect(actualAssign == nil)
     }
   }
-  
+
   @Test(arguments: numbers, numbers)
   func subtraction(_ a: Int?, _ b: Int?) {
     let expected = b.flatMap { a?.subtractingReportingOverflow($0) }
     let actualInfix = a -? b
     var actualAssign = a
     actualAssign -?= b
-    
+
     switch expected {
     case (let result, false)?:
       #expect(actualInfix == result)
@@ -55,7 +55,7 @@ struct OptionatorTests {
     let actualInfix = a *? b
     var actualAssign = a
     actualAssign *?= b
-    
+
     switch expected {
     case (let result, false)?:
       #expect(actualInfix == result)
@@ -72,7 +72,7 @@ struct OptionatorTests {
     let actualInfix = a /? b
     var actualAssign = a
     actualAssign /?= b
-    
+
     switch expected {
     case (let result, false)?:
       #expect(actualInfix == result)
@@ -89,7 +89,7 @@ struct OptionatorTests {
     let actualInfix = a %? b
     var actualAssign = a
     actualAssign %?= b
-    
+
     switch expected {
     case (let result, false)?:
       #expect(actualInfix == result)
@@ -104,7 +104,7 @@ struct OptionatorTests {
   func negation(_ a: Int?) {
     let expected = a?.multipliedReportingOverflow(by: -1)
     let actual = -?a
-    
+
     switch expected {
     case (let result, false)?:
       #expect(actual == result)
@@ -118,7 +118,7 @@ struct OptionatorTests {
     let actual = a ..<? b
     switch (a, b) {
     case (let a?, let b?) where a <= b:
-      #expect(actual == a ..< b)
+      #expect(actual == a..<b)
     default:
       #expect(actual == nil)
     }
@@ -129,7 +129,7 @@ struct OptionatorTests {
     let actual = a ...? b
     switch (a, b) {
     case (let a?, let b?) where a <= b:
-      #expect(actual == a ... b)
+      #expect(actual == a...b)
     default:
       #expect(actual == nil)
     }


### PR DESCRIPTION
To accommodate both user and library errors on parser function-taking functions (like `Range.init(parsingStartAndEnd:parser:)`), this adds a `typealias ThrownParsingError` that aliases `ParsingError` in embedded mode and `any Error` elsewhere. This has the benefit of keeping the simplicity of untyped errors in non-embedded code, but means that adopting code can't choose to use explicitly typed errors when in non-embedded mode.

Addresses #3.