### PR TITLE
Fix url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ extension QOI.Header {
 The project includes a variety of example parsers, demonstrating different 
 attributes of binary formats:
 
-- [Binary Property Lists](https://github.com/apple/swift-binary-parsing/blob/main/Examples/BPListParser/BinaryPList.swift.)
+- [Binary Property Lists](https://github.com/apple/swift-binary-parsing/blob/main/Examples/BPListParser/BinaryPList.swift)
 - [ELF](https://github.com/apple/swift-binary-parsing/blob/main/Examples/ELFParser/ELF%2BParsing.swift)
 - [LZ4](https://github.com/apple/swift-binary-parsing/blob/main/Examples/LZ4Parser/LZ4.swift)
 - [PCAP-NG](https://github.com/apple/swift-binary-parsing/blob/main/Examples/PCAPNGParser/PCAPNG.swift)


### PR DESCRIPTION
Fixed url to Binary Property List parser example

<!--
    Thanks for contributing to Swift Binary Parsing!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
