### PR TITLE
Revise the typed throws design

### DIFF
--- a/Sources/BinaryParsing/Parser Types/ParsingError.swift
+++ b/Sources/BinaryParsing/Parser Types/ParsingError.swift
@@ -121,7 +121,7 @@ extension ParsingError.Status: CustomStringConvertible {
 /// In a build for embedded Swift, `ThrownParsingError` instead aliases the
 /// specific `ParsingError` type. Because embedded Swift supports only
 /// fully-typed throws, and not the existential `any Error`, this allows you
-/// to still take use error-throwing APIs in an embedded context.
+/// to still use error-throwing APIs in an embedded context.
 public typealias ThrownParsingError = any Error
 #else
 // Documentation is built using the non-embedded build.

--- a/Sources/BinaryParsing/Parsers/Range.swift
+++ b/Sources/BinaryParsing/Parsers/Range.swift
@@ -12,11 +12,28 @@
 // MARK: Start & Count
 
 extension Range where Bound: FixedWidthInteger {
+  #if !$Embedded
   @lifetime(&input)
   public init(
     parsingStartAndCount input: inout ParserSpan,
-    parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
-  ) throws(ThrownParsingError) {
+    parser: (inout ParserSpan) throws -> Bound
+  ) throws {
+    let start = try parser(&input)
+    let count = try parser(&input)
+    guard count >= 0, let end = start +? count else {
+      throw ParsingError(
+        status: .invalidValue,
+        location: input.startPosition)
+    }
+    self = Range(uncheckedBounds: (start, end))
+  }
+  #endif
+
+  @lifetime(&input)
+  public init(
+    parsingStartAndCount input: inout ParserSpan,
+    parser: (inout ParserSpan) throws(ParsingError) -> Bound
+  ) throws(ParsingError) {
     let start = try parser(&input)
     let count = try parser(&input)
     guard count >= 0, let end = start +? count else {
@@ -29,22 +46,44 @@ extension Range where Bound: FixedWidthInteger {
 }
 
 extension ClosedRange where Bound: FixedWidthInteger {
+  #if !$Embedded
   @available(
     *, deprecated,
     message:
       "The behavior of this parser is unintuitive; instead, parse the start and count separately, then form the end of the closed range."
   )
-  @lifetime(&input)
+  @lifetime(&_input)
   public init(
-    parsingStartAndCount input: inout ParserSpan,
-    parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
-  ) throws(ThrownParsingError) {
-    let start = try parser(&input)
-    let count = try parser(&input)
+    parsingStartAndCount _input: inout ParserSpan,
+    parser: (inout ParserSpan) throws -> Bound
+  ) throws {
+    let start = try parser(&_input)
+    let count = try parser(&_input)
     guard count > 0, let end = start +? count -? 1 else {
       throw ParsingError(
         status: .invalidValue,
-        location: input.startPosition)
+        location: _input.startPosition)
+    }
+    self = ClosedRange(uncheckedBounds: (start, end))
+  }
+  #endif
+
+  @available(
+    *, deprecated,
+    message:
+      "The behavior of this parser is unintuitive; instead, parse the start and count separately, then form the end of the closed range."
+  )
+  @lifetime(&_input)
+  public init(
+    parsingStartAndCount _input: inout ParserSpan,
+    parser: (inout ParserSpan) throws(ParsingError) -> Bound
+  ) throws(ParsingError) {
+    let start = try parser(&_input)
+    let count = try parser(&_input)
+    guard count > 0, let end = start +? count -? 1 else {
+      throw ParsingError(
+        status: .invalidValue,
+        location: _input.startPosition)
     }
     self = ClosedRange(uncheckedBounds: (start, end))
   }
@@ -53,11 +92,28 @@ extension ClosedRange where Bound: FixedWidthInteger {
 // MARK: Start & End
 
 extension Range {
+  #if !$Embedded
   @lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
-    boundsParser parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
-  ) throws(ThrownParsingError) {
+    boundsParser parser: (inout ParserSpan) throws -> Bound
+  ) throws {
+    let start = try parser(&input)
+    let end = try parser(&input)
+    guard start <= end else {
+      throw ParsingError(
+        status: .invalidValue,
+        location: input.startPosition)
+    }
+    self = Range(uncheckedBounds: (start, end))
+  }
+  #endif
+
+  @lifetime(&input)
+  public init(
+    parsingStartAndEnd input: inout ParserSpan,
+    boundsParser parser: (inout ParserSpan) throws(ParsingError) -> Bound
+  ) throws(ParsingError) {
     let start = try parser(&input)
     let end = try parser(&input)
     guard start <= end else {
@@ -70,11 +126,28 @@ extension Range {
 }
 
 extension ClosedRange {
+  #if !$Embedded
   @lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
-    boundsParser parser: (inout ParserSpan) throws(ThrownParsingError) -> Bound
-  ) throws(ThrownParsingError) {
+    boundsParser parser: (inout ParserSpan) throws -> Bound
+  ) throws {
+    let start = try parser(&input)
+    let end = try parser(&input)
+    guard start <= end else {
+      throw ParsingError(
+        status: .invalidValue,
+        location: input.startPosition)
+    }
+    self = ClosedRange(uncheckedBounds: (start, end))
+  }
+  #endif
+
+  @lifetime(&input)
+  public init(
+    parsingStartAndEnd input: inout ParserSpan,
+    boundsParser parser: (inout ParserSpan) throws(ParsingError) -> Bound
+  ) throws(ParsingError) {
     let start = try parser(&input)
     let end = try parser(&input)
     guard start <= end else {

--- a/Tests/BinaryParsingTests/RangeParsingTests.swift
+++ b/Tests/BinaryParsingTests/RangeParsingTests.swift
@@ -31,11 +31,18 @@ struct RangeParsingTests {
       #expect(range2 == 3..<7)
     }
 
-    _ = try buffer.withParserSpan { span in
+    buffer.withParserSpan { span in
       // Negative count
       #expect(throws: ParsingError.self) {
         try Range(parsingStartAndCount: &span) { span in
           try -(Int16(parsingBigEndian: &span))
+        }
+      }
+
+      // Invalid values, non-throwing closure
+      #expect(throws: ParsingError.self) {
+        try Range(parsingStartAndCount: &span) { span in
+          UInt64.max
         }
       }
 
@@ -55,8 +62,7 @@ struct RangeParsingTests {
     }
   }
 
-  @Test
-  func startAndEnd() throws {
+  @Test func startAndEnd() throws {
     try buffer.withParserSpan { span in
       let range1 = try Range(parsingStartAndEnd: &span) { span in
         try Int16(parsingBigEndian: &span)
@@ -68,11 +74,18 @@ struct RangeParsingTests {
       #expect(range2 == 3..<4)
     }
 
-    _ = try buffer.withParserSpan { span in
+    buffer.withParserSpan { span in
       // Reversed start and end
       #expect(throws: ParsingError.self) {
         try Range(parsingStartAndEnd: &span) { span in
           try -(Int16(parsingBigEndian: &span))
+        }
+      }
+
+      // Invalid ends, non-throwing closure
+      #expect(throws: ParsingError.self) {
+        try Range(parsingStartAndEnd: &span) { span in
+          Double.nan
         }
       }
 
@@ -108,11 +121,18 @@ struct RangeParsingTests {
       #expect(range2 == 3...6)
     }
 
-    _ = try buffer.withParserSpan { span in
+    buffer.withParserSpan { span in
       // Reversed start and end
       #expect(throws: ParsingError.self) {
         try ClosedRange(parsingStartAndCount: &span) { span in
           try -(Int16(parsingBigEndian: &span))
+        }
+      }
+
+      // Invalid values, non-throwing closure
+      #expect(throws: ParsingError.self) {
+        try ClosedRange(parsingStartAndCount: &span) { span in
+          UInt64.max
         }
       }
 
@@ -145,11 +165,18 @@ struct RangeParsingTests {
       #expect(range2 == 3...4)
     }
 
-    _ = try buffer.withParserSpan { span in
+    buffer.withParserSpan { span in
       // Reversed start and end
       #expect(throws: ParsingError.self) {
         try ClosedRange(parsingStartAndEnd: &span) { span in
           try -(Int16(parsingBigEndian: &span))
+        }
+      }
+
+      // Invalid ends, non-throwing closure
+      #expect(throws: ParsingError.self) {
+        try ClosedRange(parsingStartAndEnd: &span) { span in
+          Double.nan
         }
       }
 


### PR DESCRIPTION
This changes the conventions for typed throws for the parser initializers that used the conditionally-defined `ThrownParsingError` type alias. Some of the parsers didn't actually need that alias, and instead could use a function-specific generic error.

For others parsers, the library now provides two overloads: one with `ParsingError`-typed errors and one with untyped errors, which is omitted in embedded contexts. Since it is more specific, the typed- error overload is chosen when a passed-in closure either does not throw or throws only `ParsingError`s.

This also reworks the methods in "ParserSource.swift" with the only thing still really using `ThrownParsingError` being the `ExpressibleByParsing` protocol, since it is significantly more wide open than the lower-level parsers.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
