### PR TITLE
Adopt strict memory safety annotations in BinaryParsing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
         .enableExperimentalFeature("Span"),
         .enableExperimentalFeature("ValueGenerics"),
         .enableExperimentalFeature("LifetimeDependence"),
+        .strictMemorySafety(),
       ]
     ),
     //    .target(

--- a/Sources/BinaryParsing/Parser Types/ParserSource.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSource.swift
@@ -50,8 +50,8 @@ extension RandomAccessCollection<UInt8> {
   ) throws(ThrownParsingError) -> T? {
     #if canImport(Foundation)
     if let data = self as? Foundation.Data {
-      let result = data.withUnsafeBytes { buffer in
-        var span = ParserSpan(_unsafeBytes: buffer)
+      let result = unsafe data.withUnsafeBytes { buffer in
+        var span = unsafe ParserSpan(_unsafeBytes: buffer)
         return Result<T, ThrownParsingError> { try body(&span) }
       }
       switch result {
@@ -63,7 +63,7 @@ extension RandomAccessCollection<UInt8> {
 
     let result = self.withContiguousStorageIfAvailable { buffer in
       let rawBuffer = UnsafeRawBufferPointer(buffer)
-      var span = ParserSpan(_unsafeBytes: rawBuffer)
+      var span = unsafe ParserSpan(_unsafeBytes: rawBuffer)
       return Result<T, ThrownParsingError> { try body(&span) }
     }
     switch result {
@@ -118,8 +118,8 @@ extension Data: ParserSpanProvider {
   public func withParserSpan<T, E>(
     _ body: (inout ParserSpan) throws(E) -> T
   ) throws(E) -> T {
-    let result = withUnsafeBytes { buffer in
-      var span = ParserSpan(_unsafeBytes: buffer)
+    let result = unsafe withUnsafeBytes { buffer in
+      var span = unsafe ParserSpan(_unsafeBytes: buffer)
       return Result<T, E> { () throws(E) in try body(&span) }
     }
     switch result {
@@ -134,8 +134,8 @@ extension [UInt8]: ParserSpanProvider {
   public func withParserSpan<T, E>(
     _ body: (inout ParserSpan) throws(E) -> T
   ) throws(E) -> T {
-    let result = self.withUnsafeBytes { rawBuffer in
-      var span = ParserSpan(_unsafeBytes: rawBuffer)
+    let result = unsafe self.withUnsafeBytes { rawBuffer in
+      var span = unsafe ParserSpan(_unsafeBytes: rawBuffer)
       return Result<T, E> { () throws(E) in try body(&span) }
     }
     switch result {
@@ -149,8 +149,8 @@ extension ArraySlice<UInt8>: ParserSpanProvider {
   public func withParserSpan<T, E>(
     _ body: (inout ParserSpan) throws(E) -> T
   ) throws(E) -> T {
-    let result = self.withUnsafeBytes { rawBuffer in
-      var span = ParserSpan(_unsafeBytes: rawBuffer)
+    let result = unsafe self.withUnsafeBytes { rawBuffer in
+      var span = unsafe ParserSpan(_unsafeBytes: rawBuffer)
       return Result<T, E> { () throws(E) in try body(&span) }
     }
     switch result {

--- a/Sources/BinaryParsing/Parser Types/ParserSpan.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSpan.swift
@@ -29,10 +29,11 @@ public struct ParserSpan: ~Escapable, BitwiseCopyable {
     self._upperBound = _bytes.byteCount
   }
 
+  @unsafe
   @inlinable
   @lifetime(borrow buffer)
   public init(_unsafeBytes buffer: UnsafeRawBufferPointer) {
-    self._bytes = RawSpan(_unsafeBytes: buffer)
+    self._bytes = unsafe RawSpan(_unsafeBytes: buffer)
     self._lowerBound = 0
     self._upperBound = _bytes.byteCount
   }
@@ -111,7 +112,7 @@ extension ParserSpan {
   subscript(offset i: Int) -> UInt8 {
     precondition(i >= 0)
     precondition(i < count)
-    return _bytes.unsafeLoad(
+    return unsafe _bytes.unsafeLoad(
       fromUncheckedByteOffset: _lowerBound &+ i,
       as: UInt8.self)
   }
@@ -124,10 +125,10 @@ extension ParserSpan {
   public func withUnsafeBytes<T, E>(
     _ body: (UnsafeRawBufferPointer) throws(E) -> T
   ) throws(E) -> T {
-    try _bytes.withUnsafeBytes { (fullBuffer) throws(E) in
-      let buffer = UnsafeRawBufferPointer(
+    try unsafe _bytes.withUnsafeBytes { (fullBuffer) throws(E) in
+      let buffer = unsafe UnsafeRawBufferPointer(
         rebasing: fullBuffer[_lowerBound..<_upperBound])
-      return try body(buffer)
+      return try unsafe body(buffer)
     }
   }
 }
@@ -153,25 +154,27 @@ extension ParserSpan {
   @discardableResult
   mutating func consume() -> UInt8? {
     guard !isEmpty else { return nil }
-    return consumeUnchecked()
+    return unsafe consumeUnchecked()
   }
 
+  @unsafe
   @inlinable
   @lifetime(copy self)
   mutating func consumeUnchecked(type: UInt8.Type = UInt8.self) -> UInt8 {
     defer { _lowerBound &+= 1 }
-    return _bytes.unsafeLoad(
+    return unsafe _bytes.unsafeLoad(
       fromUncheckedByteOffset: _lowerBound,
       as: UInt8.self)
   }
 
+  @unsafe
   @inlinable
   @lifetime(copy self)
   mutating func consumeUnchecked<T: FixedWidthInteger & BitwiseCopyable>(
     type: T.Type
   ) -> T {
     defer { _lowerBound += MemoryLayout<T>.stride }
-    return _bytes.unsafeLoadUnaligned(
+    return unsafe unsafe _bytes.unsafeLoadUnaligned(
       fromUncheckedByteOffset: _lowerBound,
       as: T.self)
   }

--- a/Sources/BinaryParsing/Parsers/Array.swift
+++ b/Sources/BinaryParsing/Parsers/Array.swift
@@ -16,8 +16,8 @@ extension Array where Element == UInt8 {
     throws(ParsingError)
   {
     defer { _ = input.divide(atOffset: input.count) }
-    self = input.withUnsafeBytes { buffer in
-      Array(buffer)
+    self = unsafe input.withUnsafeBytes { buffer in
+      unsafe Array(buffer)
     }
   }
 
@@ -27,8 +27,8 @@ extension Array where Element == UInt8 {
     throws(ParsingError)
   {
     let slice = try input._divide(atByteOffset: byteCount)
-    self = slice.withUnsafeBytes { buffer in
-      Array(buffer)
+    self = unsafe slice.withUnsafeBytes { buffer in
+      unsafe Array(buffer)
     }
   }
 }

--- a/Sources/BinaryParsing/Parsers/Range.swift
+++ b/Sources/BinaryParsing/Parsers/Range.swift
@@ -25,7 +25,7 @@ extension Range where Bound: FixedWidthInteger {
         status: .invalidValue,
         location: input.startPosition)
     }
-    self = Range(uncheckedBounds: (start, end))
+    self = unsafe Range(uncheckedBounds: (start, end))
   }
   #endif
 
@@ -41,7 +41,7 @@ extension Range where Bound: FixedWidthInteger {
         status: .invalidValue,
         location: input.startPosition)
     }
-    self = Range(uncheckedBounds: (start, end))
+    self = unsafe Range(uncheckedBounds: (start, end))
   }
 }
 
@@ -64,7 +64,7 @@ extension ClosedRange where Bound: FixedWidthInteger {
         status: .invalidValue,
         location: _input.startPosition)
     }
-    self = ClosedRange(uncheckedBounds: (start, end))
+    self = unsafe ClosedRange(uncheckedBounds: (start, end))
   }
   #endif
 
@@ -85,7 +85,7 @@ extension ClosedRange where Bound: FixedWidthInteger {
         status: .invalidValue,
         location: _input.startPosition)
     }
-    self = ClosedRange(uncheckedBounds: (start, end))
+    self = unsafe ClosedRange(uncheckedBounds: (start, end))
   }
 }
 
@@ -105,7 +105,7 @@ extension Range {
         status: .invalidValue,
         location: input.startPosition)
     }
-    self = Range(uncheckedBounds: (start, end))
+    self = unsafe Range(uncheckedBounds: (start, end))
   }
   #endif
 
@@ -121,7 +121,7 @@ extension Range {
         status: .invalidValue,
         location: input.startPosition)
     }
-    self = Range(uncheckedBounds: (start, end))
+    self = unsafe Range(uncheckedBounds: (start, end))
   }
 }
 
@@ -139,7 +139,7 @@ extension ClosedRange {
         status: .invalidValue,
         location: input.startPosition)
     }
-    self = ClosedRange(uncheckedBounds: (start, end))
+    self = unsafe ClosedRange(uncheckedBounds: (start, end))
   }
   #endif
 
@@ -155,6 +155,6 @@ extension ClosedRange {
         status: .invalidValue,
         location: input.startPosition)
     }
-    self = ClosedRange(uncheckedBounds: (start, end))
+    self = unsafe ClosedRange(uncheckedBounds: (start, end))
   }
 }

--- a/Sources/BinaryParsing/Parsers/String.swift
+++ b/Sources/BinaryParsing/Parsers/String.swift
@@ -15,22 +15,22 @@ extension String {
   public init(parsingNulTerminated input: inout ParserSpan) throws(ParsingError)
   {
     guard
-      let nulOffset = input.withUnsafeBytes({ buffer in
-        buffer.firstIndex(of: 0)
+      let nulOffset = unsafe input.withUnsafeBytes({ buffer in
+        unsafe buffer.firstIndex(of: 0)
       })
     else {
       throw ParsingError(status: .invalidValue, location: input.startPosition)
     }
     try self.init(parsingUTF8: &input, count: nulOffset)
-    _ = input.consumeUnchecked()
+    _ = unsafe input.consumeUnchecked()
   }
 
   @inlinable
   @lifetime(&input)
   public init(parsingUTF8 input: inout ParserSpan) throws(ParsingError) {
     let stringBytes = input.divide(at: input.endPosition)
-    self = stringBytes.withUnsafeBytes { buffer in
-      String(decoding: buffer, as: UTF8.self)
+    self = unsafe stringBytes.withUnsafeBytes { buffer in
+      unsafe String(decoding: buffer, as: UTF8.self)
     }
   }
 
@@ -43,15 +43,16 @@ extension String {
     try self.init(parsingUTF8: &slice)
   }
 
+  @unsafe
   @inlinable
   @lifetime(&input)
   internal init(_uncheckedParsingUTF16 input: inout ParserSpan)
     throws(ParsingError)
   {
     let stringBytes = input.divide(at: input.endPosition)
-    self = stringBytes.withUnsafeBytes { buffer in
-      let utf16Buffer = buffer.assumingMemoryBound(to: UInt16.self)
-      return String(decoding: utf16Buffer, as: UTF16.self)
+    self = unsafe stringBytes.withUnsafeBytes { buffer in
+      let utf16Buffer = unsafe buffer.assumingMemoryBound(to: UInt16.self)
+      return unsafe String(decoding: utf16Buffer, as: UTF16.self)
     }
   }
 
@@ -61,7 +62,7 @@ extension String {
     guard input.count.isMultiple(of: 2) else {
       throw ParsingError(status: .invalidValue, location: input.startPosition)
     }
-    try self.init(_uncheckedParsingUTF16: &input)
+    unsafe try self.init(_uncheckedParsingUTF16: &input)
   }
 
   @inlinable
@@ -71,6 +72,6 @@ extension String {
   {
     var slice = try input._divide(
       atByteOffset: codeUnitCount.multipliedThrowingOnOverflow(by: 2))
-    try self.init(_uncheckedParsingUTF16: &slice)
+    unsafe try self.init(_uncheckedParsingUTF16: &slice)
   }
 }


### PR DESCRIPTION
This adds the required `@unsafe` and `unsafe` annotations to enable strict memory safety for the BinaryParsing module.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
