### PR TITLE
Fix error handling for array parsing

### DIFF
--- a/Sources/BinaryParsing/Parser Types/ParsingError.swift
+++ b/Sources/BinaryParsing/Parser Types/ParsingError.swift
@@ -121,7 +121,7 @@ extension ParsingError.Status: CustomStringConvertible {
 /// In a build for embedded Swift, `ThrownParsingError` instead aliases the
 /// specific `ParsingError` type. Because embedded Swift supports only
 /// fully-typed throws, and not the existential `any Error`, this allows you to
-/// still take use error-throwing APIs in an embedded context.
+/// still use error-throwing APIs in an embedded context.
 public typealias ThrownParsingError = any Error
 #else
 // Documentation is built using the non-embedded build.

--- a/Sources/BinaryParsing/Parsers/Array.swift
+++ b/Sources/BinaryParsing/Parsers/Array.swift
@@ -80,7 +80,9 @@ extension Array {
     count: some FixedWidthInteger,
     parser: (inout ParserSpan) throws -> Element
   ) throws {
-    let count = try Int(throwingOnOverflow: count)
+    guard let count = Int(exactly: count), count >= 0 else {
+      throw ParsingError(statusOnly: .invalidValue)
+    }
     self = []
     self.reserveCapacity(count)
     // This doesn't throw (e.g. on empty) because `parser` can produce valid
@@ -118,11 +120,14 @@ extension Array {
   /// - Throws: An error if one is thrown from `parser`.
   @inlinable
   @lifetime(&input)
-  public init<E>(
+  public init(
     parsing input: inout ParserSpan,
     count: Int,
-    parser: (inout ParserSpan) throws(E) -> Element
-  ) throws(E) {
+    parser: (inout ParserSpan) throws(ThrownParsingError) -> Element
+  ) throws(ThrownParsingError) {
+    guard count >= 0 else {
+      throw ParsingError(statusOnly: .invalidValue)
+    }
     self = []
     self.reserveCapacity(count)
     // This doesn't throw (e.g. on empty) because `parser` can produce valid


### PR DESCRIPTION
Addresses an error introduced when rearranging error handling in array parsers. The validation of `count` being non-negative was dropped at some point along the way; this change brings that check back and switches the `Array(parsing:count:parser:)` initializer to throw `ThrownParsingError` instead of having a generic error type parameter.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
