### PR TITLE
Make expanded macro functions public

### DIFF
--- a/Sources/BinaryParsing/Macros/MagicNumber.swift
+++ b/Sources/BinaryParsing/Macros/MagicNumber.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 @lifetime(&input)
-func _loadAndCheckDirectBytes<
+public func _loadAndCheckDirectBytes<
   T: FixedWidthInteger & MultiByteInteger & BitwiseCopyable
 >(
   parsing input: inout ParserSpan,
@@ -24,7 +24,7 @@ func _loadAndCheckDirectBytes<
 }
 
 @lifetime(&input)
-func _loadAndCheckDirectBytesByteOrder<
+public func _loadAndCheckDirectBytesByteOrder<
   T: FixedWidthInteger & MultiByteInteger & BitwiseCopyable
 >(
   parsing input: inout ParserSpan,


### PR DESCRIPTION
Make the functions that `#magicNumber` expands into public, so that they're actually callable…

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
