### PR TITLE
List all platform baselines

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ import PackageDescription
 
 let package = Package(
   name: "swift-binary-parsing",
-  platforms: [.macOS(.v15)],
+  platforms: [.macOS(.v15), .iOS(.v18), .watchOS(.v11), .tvOS(.v18), .visionOS(.v1)],
   products: [
     .library(name: "BinaryParsing", targets: ["BinaryParsing"])
     //    .library(name: "BinaryParsingEmbedded", targets: ["BinaryParsingEmbedded"]),


### PR DESCRIPTION
Adds the equivalent platform baselines to macOS 15 – I suspect these will be able to go lower once the `Span` compatibility implementation is complete and propagated…
