### PR TITLE
Provide a link to gh-pages hosted docs

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,3 @@
 version: 1
-builder:
-  configs:
-    - documentation_targets: [BinaryParsing]
+external_links:
+  documentation: "https://apple.github.io/swift-binary-parsing/documentation/binaryparsing/"


### PR DESCRIPTION
Swift Package Index is currently building docs in the 6.1 build, which doesn't work for this packge. We can self-host until that changes.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
