### PR TITLE
Add `Data` parsers to match Array<UInt8>

### DIFF
--- a/Sources/BinaryParsing/Documentation.docc/Articles/MiscellaneousParsers.md
+++ b/Sources/BinaryParsing/Documentation.docc/Articles/MiscellaneousParsers.md
@@ -1,6 +1,6 @@
 # Miscellaneous Parsers
 
-Parse ranges and custom raw representable types.
+Parse ranges and custom raw representable types, or raw bytes into Foundation's `Data`.
 
 ## Topics
 
@@ -20,3 +20,8 @@ Parse ranges and custom raw representable types.
 - ``Swift/RawRepresentable/init(parsing:storedAsBigEndian:)``
 - ``Swift/RawRepresentable/init(parsing:storedAsLittleEndian:)``
 - ``Swift/RawRepresentable/init(parsing:storedAs:endianness:)``
+
+### Data parsers
+
+- ``Foundation/Data/init(parsingRemainingBytes:)``
+- ``Foundation/Data/init(parsing:byteCount:)``

--- a/Sources/BinaryParsing/Parsers/Data.swift
+++ b/Sources/BinaryParsing/Parsers/Data.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Binary Parsing open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+public import Foundation
+
+extension Data {
+  /// Creates a new data instance by copying the remaining bytes from the
+  /// given parser span.
+  ///
+  /// Unlike most parsers, this initializer does not throw.
+  ///
+  /// - Parameter input: The `ParserSpan` to consume.
+  @inlinable
+  @lifetime(&input)
+  public init(parsingRemainingBytes input: inout ParserSpan) {
+    defer { _ = input.divide(atOffset: input.count) }
+    self = unsafe input.withUnsafeBytes { buffer in
+      unsafe Data(buffer)
+    }
+  }
+
+  /// Creates a new data instance by copying the specified number of bytes
+  /// from the given parser span.
+  ///
+  /// - Parameters:
+  ///   - input: The `ParserSpan` to consume.
+  ///   - byteCount: The number of bytes to copy into the resulting array.
+  /// - Throws: A `ParsingError` if `input` does not have at least `byteCount`
+  ///   bytes remaining.
+  @inlinable
+  @lifetime(&input)
+  public init(parsing input: inout ParserSpan, byteCount: Int)
+    throws(ParsingError)
+  {
+    let slice = try input._divide(atByteOffset: byteCount)
+    self = unsafe slice.withUnsafeBytes { buffer in
+      unsafe Data(buffer)
+    }
+  }
+}
+#endif

--- a/Tests/BinaryParsingTests/DataParsingTests.swift
+++ b/Tests/BinaryParsingTests/DataParsingTests.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Binary Parsing open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Foundation)
+import BinaryParsing
+import Foundation
+import Testing
+
+struct DataParsingTests {
+  private let testBuffer: [UInt8] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+  ]
+
+  private let emptyBuffer: [UInt8] = []
+
+  @Test
+  func parseRemainingBytes() throws {
+    testBuffer.withParserSpan { span in
+      let parsedData = Data(parsingRemainingBytes: &span)
+      #expect(parsedData.elementsEqual(testBuffer))
+      #expect(span.count == 0)
+    }
+
+    // Test parsing after consuming part of the buffer
+    testBuffer.withParserSpan { span in
+      try! span.seek(toRelativeOffset: 3)
+      let parsedData = Data(parsingRemainingBytes: &span)
+      #expect(parsedData.elementsEqual(testBuffer.dropFirst(3)))
+      #expect(span.count == 0)
+    }
+
+    // Test parsing smaller range of buffer
+    try testBuffer.withParserSpan { span in
+      try span.seek(toRelativeOffset: 3)
+      var smallerSpan = try span.sliceSpan(byteCount: 4)
+      let parsedData = Data(parsingRemainingBytes: &smallerSpan)
+      #expect(parsedData.elementsEqual(testBuffer.dropFirst(3).prefix(4)))
+      #expect(smallerSpan.count == 0)
+    }
+
+    // Test with an empty span
+    emptyBuffer.withParserSpan { span in
+      let parsedData = Data(parsingRemainingBytes: &span)
+      #expect(parsedData.isEmpty)
+    }
+  }
+
+  @Test
+  func parseByteCount() throws {
+    try testBuffer.withParserSpan { span in
+      let parsedData = try Data(parsing: &span, byteCount: 5)
+      #expect(parsedData.elementsEqual(testBuffer.prefix(5)))
+      #expect(span.count == 5)
+
+      let parsedData2 = try Data(parsing: &span, byteCount: 3)
+      #expect(parsedData2.elementsEqual(testBuffer.dropFirst(5).prefix(3)))
+      #expect(span.count == 2)
+    }
+
+    // 'byteCount' == 0
+    try testBuffer.withParserSpan { span in
+      let parsedData = try Data(parsing: &span, byteCount: 0)
+      #expect(parsedData.isEmpty)
+      #expect(span.count == testBuffer.count)
+    }
+
+    // 'byteCount' greater than available bytes
+    testBuffer.withParserSpan { span in
+      #expect(throws: ParsingError.self) {
+        _ = try Data(parsing: &span, byteCount: testBuffer.count + 1)
+      }
+      #expect(span.count == testBuffer.count)
+    }
+
+    // Negative 'byteCount'
+    testBuffer.withParserSpan { span in
+      #expect(throws: ParsingError.self) {
+        _ = try Data(parsing: &span, byteCount: -1)
+      }
+      #expect(span.count == testBuffer.count)
+    }
+  }
+}
+#endif


### PR DESCRIPTION
The library already provides parsers that copy the raw binary data from a `ParserSpan` into an `Array<UInt8>` – this change adds the same tools for copying into a `Data` instance.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
