### PR TITLE
Update to latest lifetimes syntax

### DIFF
--- a/Examples/BPListParser/BinaryPList.swift
+++ b/Examples/BPListParser/BinaryPList.swift
@@ -83,7 +83,7 @@ extension BPList.Trailer {
 
 extension Int {
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsingBPListCount input: inout ParserSpan, countMarker: UInt8) throws {
     if countMarker != 0xf {
       self = Int(countMarker)
@@ -146,7 +146,7 @@ extension BPList {
     }
 
     @inlinable
-    @lifetime(&input)
+    @_lifetime(&input)
     init(parsingIndexAndObject input: inout ParserSpan, trailingObject: Trailer)
       throws
     {
@@ -158,7 +158,7 @@ extension BPList {
     }
 
     @inlinable
-    @lifetime(&input)
+    @_lifetime(&input)
     init(parsing input: inout ParserSpan, trailingObject: Trailer) throws {
       let marker = try UInt8(parsing: &input)
 

--- a/Examples/BPListParser/Deferred.swift
+++ b/Examples/BPListParser/Deferred.swift
@@ -39,7 +39,7 @@ public struct DeferredBPList {
       self.pos = pos
     }
 
-    @lifetime(&input)
+    @_lifetime(&input)
     @usableFromInline
     init(parsing input: inout ParserSpan, trailingObject: BPList.Trailer) throws
     {
@@ -107,7 +107,7 @@ extension DeferredBPList {
       }
     }
 
-    @lifetime(&input)
+    @_lifetime(&input)
     init(
       parsingIndexAndObject input: inout ParserSpan,
       trailingObject: BPList.Trailer
@@ -119,7 +119,7 @@ extension DeferredBPList {
       self = try Object(parsing: &objectBuffer, trailingObject: trailingObject)
     }
 
-    @lifetime(&input)
+    @_lifetime(&input)
     @usableFromInline
     init(parsing input: inout ParserSpan, trailingObject: BPList.Trailer) throws
     {

--- a/Examples/ELFParser/ELF+Parsing.swift
+++ b/Examples/ELFParser/ELF+Parsing.swift
@@ -50,7 +50,7 @@ extension ELF: ExpressibleByParsing {
 }
 
 extension ELF.ProgramHeader {
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsing input: inout ParserSpan, class: ELF.Header.Class, endian: Endianness
   ) throws {
@@ -89,7 +89,7 @@ extension ELF.ProgramHeader {
 }
 
 extension ELF.SectionHeader {
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsing input: inout ParserSpan, class: ELF.Header.Class, endian: Endianness
   ) throws {

--- a/Examples/LZ4Parser/LZ4.swift
+++ b/Examples/LZ4Parser/LZ4.swift
@@ -18,7 +18,7 @@ import Foundation
 
 extension Int {
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     parsingLZ4Sequence input: inout ParserSpan, token: UInt8, constant: UInt8
   ) throws {

--- a/Examples/PCAPNGParser/Blocks/Block.swift
+++ b/Examples/PCAPNGParser/Blocks/Block.swift
@@ -17,7 +17,7 @@ public enum Block {
   case enhancedPacket(EnhancedPacket)
   case custom(code: String, buffer: [UInt8])
 
-  @lifetime(&input)
+  @_lifetime(&input)
   static func custom(
     parsing input: inout ParserSpan, code: UInt32, endianness: Endianness
   ) throws -> Self {
@@ -35,7 +35,7 @@ public enum Block {
     return .custom(code: String(code, radix: 16), buffer: data)
   }
 
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan, endianness: Endianness) throws {
     let code = try UInt32(parsing: &input, endianness: endianness)
     self =

--- a/Examples/PCAPNGParser/Blocks/BlockOption.swift
+++ b/Examples/PCAPNGParser/Blocks/BlockOption.swift
@@ -12,7 +12,7 @@
 import BinaryParsing
 
 protocol BlockOption: Equatable {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     parsing input: inout ParserSpan,
     for optionCode: UInt16,
@@ -23,7 +23,7 @@ protocol BlockOption: Equatable {
 }
 
 extension BlockOption {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan, endianness: Endianness) throws {
     let optionCode = try UInt16(parsing: &input, endianness: endianness)
     let optionSize = try Int(

--- a/Examples/PCAPNGParser/Blocks/EnhancedPacket.swift
+++ b/Examples/PCAPNGParser/Blocks/EnhancedPacket.swift
@@ -20,7 +20,7 @@ public struct EnhancedPacket {
     case sha1(UInt64, UInt64, UInt8)
     case toeplitz(UInt32)
 
-    @lifetime(&input)
+    @_lifetime(&input)
     init(parsing input: inout ParserSpan, endianness: Endianness) throws {
       let code = try UInt8(parsing: &input)
       self =
@@ -90,7 +90,7 @@ public struct EnhancedPacket {
   public var packetData: Packet
   public var options: [Option]
 
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan, endianness: Endianness) throws {
     //                         1                   2                   3
     //     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -155,7 +155,7 @@ public struct EnhancedPacket {
 }
 
 extension EnhancedPacket.Option: BlockOption {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     parsing input: inout ParserSpan, for optionCode: UInt16,
     endianness: Endianness
@@ -190,7 +190,7 @@ extension EnhancedPacket.Option: BlockOption {
 }
 
 extension EnhancedPacket.Packet {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan, endianness: Endianness) throws {
     self.hasPreamble =
       try UInt64(parsing: &input, endianness: endianness)

--- a/Examples/PCAPNGParser/Blocks/InterfaceDescription.swift
+++ b/Examples/PCAPNGParser/Blocks/InterfaceDescription.swift
@@ -51,7 +51,7 @@ public struct InterfaceDescription {
     self.options = options
   }
 
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan, endianness: Endianness) throws {
     //     0                   1                   2                   3
     //     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -90,7 +90,7 @@ public struct InterfaceDescription {
 }
 
 extension InterfaceDescription.Option: BlockOption {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     parsing input: inout ParserSpan, for optionCode: UInt16,
     endianness: Endianness

--- a/Examples/PCAPNGParser/Blocks/SectionHeader.swift
+++ b/Examples/PCAPNGParser/Blocks/SectionHeader.swift
@@ -108,7 +108,7 @@ public struct SectionHeader: Equatable {
 }
 
 extension SectionHeader.Option: BlockOption {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     parsing input: inout ParserSpan,
     for optionCode: UInt16,

--- a/Examples/PNGParser/Chunks/Chunk.swift
+++ b/Examples/PNGParser/Chunks/Chunk.swift
@@ -19,7 +19,7 @@ public enum Chunk {
   case other(String, [UInt8])
   case end
 
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan) throws {
     let length = try UInt32(parsingBigEndian: &input)
     let id = try UInt32(parsingBigEndian: &input)

--- a/Examples/QOIParser/QOI.swift
+++ b/Examples/QOIParser/QOI.swift
@@ -110,7 +110,7 @@ extension Pixel {
     )
   }
 
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsingRGB input: inout ParserSpan, alpha: UInt8) throws {
     self.v = try (
       UInt8(parsing: &input),
@@ -127,7 +127,7 @@ extension Pixel {
     self.v.b &+= (b1 & 0x03) &- 2
   }
 
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     parsingLuma input: inout ParserSpan, initialByte b1: UInt8,
     previous: Pixel

--- a/Examples/RawParser/Raw.swift
+++ b/Examples/RawParser/Raw.swift
@@ -24,7 +24,7 @@ public func parseRaw(
 }
 
 extension String {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsingRaw input: inout ParserSpan, digits: Int, offset: Int) throws {
     let start = input.startPosition
     let row = try Array(parsing: &input, byteCount: Swift.min(16, input.count))

--- a/Package.swift
+++ b/Package.swift
@@ -37,9 +37,8 @@ let package = Package(
       name: "BinaryParsing",
       dependencies: ["BinaryParsingMacros"],
       swiftSettings: [
-        .enableExperimentalFeature("Span"),
         .enableExperimentalFeature("ValueGenerics"),
-        .enableExperimentalFeature("LifetimeDependence"),
+        .enableExperimentalFeature("Lifetimes"),
         .strictMemorySafety(),
       ]
     ),
@@ -71,7 +70,7 @@ let package = Package(
       dependencies: ["BinaryParsing"],
       path: "Examples",
       swiftSettings: [
-        .enableExperimentalFeature("LifetimeDependence")
+        .enableExperimentalFeature("Lifetimes"),
       ]
     ),
     .executableTarget(
@@ -89,7 +88,7 @@ let package = Package(
       ],
       swiftSettings: [
         .enableUpcomingFeature("MemberImportVisibility"),
-        .enableExperimentalFeature("LifetimeDependence"),
+        .enableExperimentalFeature("Lifetimes"),
       ]
     ),
     .testTarget(

--- a/Sources/BinaryParsing/Macros/MagicNumber.swift
+++ b/Sources/BinaryParsing/Macros/MagicNumber.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@lifetime(&input)
+@_lifetime(&input)
 public func _loadAndCheckDirectBytes<
   T: FixedWidthInteger & MultiByteInteger & BitwiseCopyable
 >(
@@ -23,7 +23,7 @@ public func _loadAndCheckDirectBytes<
   }
 }
 
-@lifetime(&input)
+@_lifetime(&input)
 public func _loadAndCheckDirectBytesByteOrder<
   T: FixedWidthInteger & MultiByteInteger & BitwiseCopyable
 >(

--- a/Sources/BinaryParsing/Parser Types/ParserSource.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSource.swift
@@ -30,7 +30,7 @@ public import Foundation
 ///     let imageData = try Data(contentsOfFile: ...)
 ///     let qoiImage = try QOI(parsing: imageData)
 public protocol ExpressibleByParsing {
-  @lifetime(&input)
+  @_lifetime(&input)
   init(parsing input: inout ParserSpan) throws(ThrownParsingError)
 }
 

--- a/Sources/BinaryParsing/Parser Types/ParserSpan.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSpan.swift
@@ -26,7 +26,7 @@ public struct ParserSpan: ~Escapable, ~Copyable {
   /// The resulting `ParserSpan` has a lifetime copied from the raw span
   /// passed as `bytes`.
   @inlinable
-  @lifetime(copy bytes)
+  @_lifetime(copy bytes)
   public init(_ bytes: RawSpan) {
     self._bytes = bytes
     self._lowerBound = 0
@@ -34,7 +34,7 @@ public struct ParserSpan: ~Escapable, ~Copyable {
   }
 
   @inlinable
-  @lifetime(copy other)
+  @_lifetime(copy other)
   init(copying other: borrowing ParserSpan) {
     self._bytes = other._bytes
     self._lowerBound = other._lowerBound
@@ -43,7 +43,7 @@ public struct ParserSpan: ~Escapable, ~Copyable {
 
   @unsafe
   @inlinable
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(_unsafeBytes buffer: UnsafeRawBufferPointer) {
     self._bytes = unsafe RawSpan(_unsafeBytes: buffer)
     self._lowerBound = 0
@@ -67,7 +67,7 @@ public struct ParserSpan: ~Escapable, ~Copyable {
   /// The resulting `RawSpan` has a lifetime copied from this parser span.
   public var bytes: RawSpan {
     @inlinable
-    @lifetime(copy self)
+    @_lifetime(copy self)
     borrowing get {
       _bytes._extracting(droppingFirst: _lowerBound)._extracting(first: count)
     }
@@ -101,7 +101,7 @@ extension ParserSpan {
   ///
   /// - Precondition: `index` must in the range `startPosition...endPosition`.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   mutating func divide(at index: Int) -> ParserSpan {
     precondition(index >= _lowerBound)
     precondition(index <= _upperBound)
@@ -117,7 +117,7 @@ extension ParserSpan {
   ///
   /// - Precondition: `offset` must in the range `0...count`.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   mutating func divide(atOffset offset: Int) -> ParserSpan {
     divide(at: startPosition &+ offset)
   }
@@ -148,7 +148,7 @@ extension ParserSpan {
 }
 
 extension ParserSpan {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   @usableFromInline
   internal mutating func _divide(
     atByteOffset count: some FixedWidthInteger
@@ -173,7 +173,7 @@ extension ParserSpan {
 
   @unsafe
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   mutating func consumeUnchecked(type: UInt8.Type = UInt8.self) -> UInt8 {
     defer { _lowerBound &+= 1 }
     return unsafe _bytes.unsafeLoad(
@@ -183,7 +183,7 @@ extension ParserSpan {
 
   @unsafe
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   mutating func consumeUnchecked<T: FixedWidthInteger & BitwiseCopyable>(
     type: T.Type
   ) -> T {
@@ -202,7 +202,7 @@ extension ParserSpan {
   /// later stage might render the entire parsing operation a failure. Using
   /// `atomically` guarantees that the input span isn't modified in that case.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func atomically<T, E>(
     _ body: (inout ParserSpan) throws(E) -> T
   ) throws(E) -> T {

--- a/Sources/BinaryParsing/Parser Types/Seeking.swift
+++ b/Sources/BinaryParsing/Parser Types/Seeking.swift
@@ -22,7 +22,7 @@ extension ParserSpan {
   /// - Returns: A new parser span positioned at `range`.
   /// - Throws: A `ParsingError` if `range` is out of bounds for this span.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func seeking(toRange range: ParserRange)
     throws(ParsingError) -> ParserSpan
   {
@@ -60,7 +60,7 @@ extension ParserSpan {
   /// - Throws: A `ParsingError` if `offset` is not in the closed range
   ///   `0...count`.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func seeking(toRelativeOffset offset: some FixedWidthInteger)
     throws(ParsingError) -> ParserSpan
   {
@@ -102,7 +102,7 @@ extension ParserSpan {
   /// - Throws: A `ParsingError` if `offset` is not in the closed range
   ///   `0...bytes.count`.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func seeking(toAbsoluteOffset offset: some FixedWidthInteger)
     throws(ParsingError) -> ParserSpan
   {
@@ -142,7 +142,7 @@ extension ParserSpan {
   /// - Throws: A `ParsingError` if `offset` is not in the closed range
   ///   `0...bytes.count`.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func seeking(toOffsetFromEnd offset: some FixedWidthInteger)
     throws(ParsingError) -> ParserSpan
   {
@@ -164,7 +164,7 @@ extension ParserSpan {
   /// - Parameter range: The range to seek to.
   /// - Throws: A `ParsingError` if `range` is out of bounds for this span.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func seek(toRange range: ParserRange) throws(ParsingError) {
     guard (0..._bytes.byteCount).contains(range.lowerBound),
       (0..._bytes.byteCount).contains(range.upperBound)
@@ -204,7 +204,7 @@ extension ParserSpan {
   /// - Throws: A `ParsingError` if `offset` is not in the closed range
   ///   `0...count`.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func seek(toRelativeOffset offset: some FixedWidthInteger)
     throws(ParsingError)
   {
@@ -249,7 +249,7 @@ extension ParserSpan {
   /// - Throws: A `ParsingError` if `offset` is not in the closed range
   ///   `0...bytes.count`.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func seek(toAbsoluteOffset offset: some FixedWidthInteger)
     throws(ParsingError)
   {
@@ -293,7 +293,7 @@ extension ParserSpan {
   /// - Throws: A `ParsingError` if `offset` is not in the closed range
   ///   `0...count`.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func seek(toOffsetFromEnd offset: some FixedWidthInteger)
     throws(ParsingError)
   {

--- a/Sources/BinaryParsing/Parser Types/Slicing.swift
+++ b/Sources/BinaryParsing/Parser Types/Slicing.swift
@@ -27,7 +27,7 @@ extension ParserSpan {
   ///   `Int`, if it's negative, or if there aren't enough bytes in the
   ///   original span.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public mutating func sliceSpan(byteCount: some FixedWidthInteger)
     throws(ParsingError) -> ParserSpan
   {
@@ -60,7 +60,7 @@ extension ParserSpan {
   ///   cannot be represented as an `Int`, if their product would overflow, or
   ///   if the product is not in the range `0...count`.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public mutating func sliceSpan(
     objectStride: some FixedWidthInteger,
     objectCount: some FixedWidthInteger
@@ -98,7 +98,7 @@ extension ParserSpan {
   ///   `Int`, if it's negative, or if there aren't enough bytes in the
   ///   original span.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func sliceRange(byteCount: some FixedWidthInteger)
     throws(ParsingError) -> ParserRange
   {
@@ -129,7 +129,7 @@ extension ParserSpan {
   ///   cannot be represented as an `Int`, if their product would overflow, or
   ///   if the product is not in the range `0...count`.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func sliceRange(
     objectStride: some FixedWidthInteger,
     objectCount: some FixedWidthInteger
@@ -148,7 +148,7 @@ extension ParserSpan {
   /// - Returns: A parser range covering the rest of the memory represented
   ///   by this parser span.
   @inlinable
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func sliceRemainingRange() -> ParserRange {
     divide(atOffset: self.count).parserRange
   }
@@ -174,7 +174,7 @@ extension ParserSpan {
   ///   `Int`, if it's negative, if there aren't enough bytes in the original
   ///   span, or if the bytes don't form valid UTF-8.
   @inlinable
-  @lifetime(copy self)
+  @_lifetime(copy self)
   @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
   public mutating func sliceUTF8Span(byteCount: some FixedWidthInteger)
     throws(ParsingError) -> UTF8Span

--- a/Sources/BinaryParsing/Parsers/Array.swift
+++ b/Sources/BinaryParsing/Parsers/Array.swift
@@ -17,7 +17,7 @@ extension Array where Element == UInt8 {
   ///
   /// - Parameter input: The `ParserSpan` to consume.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingRemainingBytes input: inout ParserSpan) {
     defer { _ = input.divide(atOffset: input.count) }
     self = unsafe input.withUnsafeBytes { buffer in
@@ -34,7 +34,7 @@ extension Array where Element == UInt8 {
   /// - Throws: A `ParsingError` if `input` does not have at least `byteCount`
   ///   bytes remaining.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsing input: inout ParserSpan, byteCount: Int)
     throws(ParsingError)
   {
@@ -74,7 +74,7 @@ extension Array {
   /// - Throws: An error if one is thrown from `parser`, or if `count` isn't
   ///   representable.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsing input: inout ParserSpan,
     count: some FixedWidthInteger,
@@ -119,7 +119,7 @@ extension Array {
   ///   - parser: A closure that parses each element from `input`.
   /// - Throws: An error if one is thrown from `parser`.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsing input: inout ParserSpan,
     count: Int,
@@ -161,7 +161,7 @@ extension Array {
   ///   - parser: A closure that parses each element from `input`.
   /// - Throws: An error if one is thrown from `parser`.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<E>(
     parsingAll input: inout ParserSpan,
     parser: (inout ParserSpan) throws(E) -> Element

--- a/Sources/BinaryParsing/Parsers/Data.swift
+++ b/Sources/BinaryParsing/Parsers/Data.swift
@@ -20,7 +20,7 @@ extension Data {
   ///
   /// - Parameter input: The `ParserSpan` to consume.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingRemainingBytes input: inout ParserSpan) {
     defer { _ = input.divide(atOffset: input.count) }
     self = unsafe input.withUnsafeBytes { buffer in
@@ -37,7 +37,7 @@ extension Data {
   /// - Throws: A `ParsingError` if `input` does not have at least `byteCount`
   ///   bytes remaining.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsing input: inout ParserSpan, byteCount: Int)
     throws(ParsingError)
   {

--- a/Sources/BinaryParsing/Parsers/Integer.swift
+++ b/Sources/BinaryParsing/Parsers/Integer.swift
@@ -36,7 +36,7 @@ extension FixedWidthInteger {
 extension FixedWidthInteger where Self: BitwiseCopyable {
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsingBigEndian input: inout ParserSpan
@@ -45,7 +45,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _parsingBigEndian input: inout ParserSpan
   ) throws(ParsingError) {
@@ -55,7 +55,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsingLittleEndian input: inout ParserSpan
@@ -64,7 +64,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(_parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
     try input._checkCount(minimum: MemoryLayout<Self>.size)
     unsafe self.init(_unchecked: (), _parsingLittleEndian: &input)
@@ -72,7 +72,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsingSigned input: inout ParserSpan,
@@ -110,7 +110,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsingUnsigned input: inout ParserSpan,
@@ -133,7 +133,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsingSigned input: inout ParserSpan,
@@ -195,7 +195,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsingUnsigned input: inout ParserSpan,
@@ -232,7 +232,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _unchecked _: Void,
     _parsing input: inout ParserSpan,
@@ -262,7 +262,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   init(
     _parsing input: inout ParserSpan,
     endianness: Endianness,
@@ -283,7 +283,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 extension MultiByteInteger {
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(_unchecked _: Void, parsingBigEndian input: inout ParserSpan) {
     unsafe self.init(_unchecked: (), _parsingBigEndian: &input)
   }
@@ -297,14 +297,14 @@ extension MultiByteInteger {
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   this integer type.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingBigEndian input: inout ParserSpan) throws(ParsingError) {
     try self.init(_parsingBigEndian: &input)
   }
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(_unchecked _: Void, parsingLittleEndian input: inout ParserSpan) {
     unsafe self.init(_unchecked: (), _parsingLittleEndian: &input)
   }
@@ -318,7 +318,7 @@ extension MultiByteInteger {
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   this integer type.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError)
   {
     try self.init(_parsingLittleEndian: &input)
@@ -326,7 +326,7 @@ extension MultiByteInteger {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     _unchecked _: Void, parsing input: inout ParserSpan, endianness: Endianness
   ) {
@@ -346,7 +346,7 @@ extension MultiByteInteger {
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   this integer type.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsing input: inout ParserSpan, endianness: Endianness)
     throws(ParsingError)
   {
@@ -360,7 +360,7 @@ extension MultiByteInteger {
 extension SingleByteInteger {
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(_unchecked _: Void, parsing input: inout ParserSpan) {
     self = unsafe input.consumeUnchecked(type: Self.self)
   }
@@ -382,7 +382,7 @@ extension SingleByteInteger {
   }
 
   @unsafe
-  @lifetime(&input)
+  @_lifetime(&input)
   @available(
     *, deprecated,
     message: "This initializer should only be used for performance testing."
@@ -396,7 +396,7 @@ extension SingleByteInteger {
 extension FixedWidthInteger where Self: BitwiseCopyable {
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     _unchecked _: Void, parsingBigEndian input: inout ParserSpan, byteCount: Int
   ) throws(ParsingError) {
@@ -420,7 +420,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   /// - Throws: A `ParsingError` if `input` contains fewer than `byteCount`
   ///   bytes, or if the parsed value overflows this integer type.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingBigEndian input: inout ParserSpan, byteCount: Int)
     throws(ParsingError)
   {
@@ -429,7 +429,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     _unchecked _: Void, parsingLittleEndian input: inout ParserSpan,
     byteCount: Int
@@ -455,7 +455,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   /// - Throws: A `ParsingError` if `input` contains fewer than `byteCount`
   ///   bytes, or if the parsed value overflows this integer type.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingLittleEndian input: inout ParserSpan, byteCount: Int)
     throws(ParsingError)
   {
@@ -464,7 +464,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     _unchecked _: Void, parsing input: inout ParserSpan, endianness: Endianness,
     byteCount: Int
@@ -492,7 +492,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   ///   bytes, if the parsed value overflows this integer type, or if the
   ///   padding bytes are invalid.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsing input: inout ParserSpan, endianness: Endianness, byteCount: Int
   ) throws(ParsingError) {
@@ -502,7 +502,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     _unchecked _: Void,
     parsing input: inout ParserSpan,
@@ -537,7 +537,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   ///   `storageType`, or if converting the parsed value to this integer type
   ///   overflows.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     parsing input: inout ParserSpan,
     storedAsBigEndian storageType: T.Type
@@ -548,7 +548,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     _unchecked _: Void,
     parsing input: inout ParserSpan,
@@ -583,7 +583,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   ///   `storageType`, or if converting the parsed value to this integer type
   ///   overflows.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     parsing input: inout ParserSpan,
     storedAsLittleEndian storageType: T.Type
@@ -594,7 +594,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     _unchecked _: Void,
     parsing input: inout ParserSpan,
@@ -634,7 +634,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   ///   `storageType`, or if converting the parsed value to this integer type
   ///   overflows.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     parsing input: inout ParserSpan,
     storedAs storageType: T.Type,
@@ -649,7 +649,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: SingleByteInteger>(
     _unchecked _: Void,
     parsing input: inout ParserSpan,
@@ -684,7 +684,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
   ///   `storageType`, or if converting the parsed value to this integer type
   ///   overflows.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: SingleByteInteger>(
     parsing input: inout ParserSpan,
     storedAs storageType: T.Type
@@ -700,20 +700,20 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
 
 extension RawRepresentable where RawValue: MultiByteInteger {
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingBigEndian input: inout ParserSpan) throws(ParsingError) {
     self = try Self(_rawValueThrowing: .init(parsingBigEndian: &input))
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError)
   {
     self = try Self(_rawValueThrowing: .init(parsingLittleEndian: &input))
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsing input: inout ParserSpan, endianness: Endianness)
     throws(ParsingError)
   {
@@ -725,7 +725,7 @@ extension RawRepresentable where RawValue: MultiByteInteger {
 
 extension RawRepresentable where RawValue: SingleByteInteger {
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsing input: inout ParserSpan) throws(ParsingError) {
     guard let value = try Self(rawValue: .init(_parsingBigEndian: &input))
     else {
@@ -749,7 +749,7 @@ extension RawRepresentable where RawValue: FixedWidthInteger & BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     parsing input: inout ParserSpan,
     storedAsBigEndian storageType: T.Type
@@ -760,7 +760,7 @@ extension RawRepresentable where RawValue: FixedWidthInteger & BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     parsing input: inout ParserSpan,
     storedAsLittleEndian storageType: T.Type
@@ -771,7 +771,7 @@ extension RawRepresentable where RawValue: FixedWidthInteger & BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: MultiByteInteger>(
     parsing input: inout ParserSpan,
     storedAs: T.Type,
@@ -783,7 +783,7 @@ extension RawRepresentable where RawValue: FixedWidthInteger & BitwiseCopyable {
   }
 
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init<T: SingleByteInteger>(
     parsing input: inout ParserSpan,
     storedAs: T.Type

--- a/Sources/BinaryParsing/Parsers/Range.swift
+++ b/Sources/BinaryParsing/Parsers/Range.swift
@@ -25,7 +25,7 @@ extension Range where Bound: FixedWidthInteger {
   ///   - input: The `ParserSpan` to parse from.
   ///   - parser: The closure to use when parsing the start and count.
   /// - Throws: An error if `parser` throws an error.
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsingStartAndCount input: inout ParserSpan,
     parser: (inout ParserSpan) throws -> Bound
@@ -53,7 +53,7 @@ extension Range where Bound: FixedWidthInteger {
   ///   - input: The `ParserSpan` to parse from.
   ///   - parser: The closure to use when parsing the start and count.
   /// - Throws: An error if `parser` throws an error.
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsingStartAndCount input: inout ParserSpan,
     parser: (inout ParserSpan) throws(ParsingError) -> Bound
@@ -76,7 +76,7 @@ extension ClosedRange where Bound: FixedWidthInteger {
     message:
       "The behavior of this parser is unintuitive; instead, parse the start and count separately, then form the end of the closed range."
   )
-  @lifetime(&_input)
+  @_lifetime(&_input)
   public init(
     parsingStartAndCount _input: inout ParserSpan,
     parser: (inout ParserSpan) throws -> Bound
@@ -97,7 +97,7 @@ extension ClosedRange where Bound: FixedWidthInteger {
     message:
       "The behavior of this parser is unintuitive; instead, parse the start and count separately, then form the end of the closed range."
   )
-  @lifetime(&_input)
+  @_lifetime(&_input)
   public init(
     parsingStartAndCount _input: inout ParserSpan,
     parser: (inout ParserSpan) throws(ParsingError) -> Bound
@@ -129,7 +129,7 @@ extension Range {
   ///   - input: The `ParserSpan` to parse from.
   ///   - parser: The closure to use when parsing the start and end.
   /// - Throws: An error if `parser` throws an error.
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
     boundsParser parser: (inout ParserSpan) throws -> Bound
@@ -157,7 +157,7 @@ extension Range {
   ///   - input: The `ParserSpan` to parse from.
   ///   - parser: The closure to use when parsing the start and end.
   /// - Throws: An error if `parser` throws an error.
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
     boundsParser parser: (inout ParserSpan) throws(ParsingError) -> Bound
@@ -187,7 +187,7 @@ extension ClosedRange {
   ///   - input: The `ParserSpan` to parse from.
   ///   - parser: The closure to use when parsing the start and end.
   /// - Throws: An error if `parser` throws an error.
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
     boundsParser parser: (inout ParserSpan) throws -> Bound
@@ -215,7 +215,7 @@ extension ClosedRange {
   ///   - input: The `ParserSpan` to parse from.
   ///   - parser: The closure to use when parsing the start and end.
   /// - Throws: An error if `parser` throws an error.
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(
     parsingStartAndEnd input: inout ParserSpan,
     boundsParser parser: (inout ParserSpan) throws(ParsingError) -> Bound

--- a/Sources/BinaryParsing/Parsers/String.swift
+++ b/Sources/BinaryParsing/Parsers/String.swift
@@ -15,7 +15,7 @@ extension String {
   /// The bytes of the string and the NUL are all consumed from `input`. This
   /// initializer throws an error if `input` does not contain a NUL byte.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingNulTerminated input: inout ParserSpan) throws(ParsingError)
   {
     guard
@@ -35,7 +35,7 @@ extension String {
   /// code units are repaired by replacing with the Unicode replacement
   /// character `U+FFFD`.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingUTF8 input: inout ParserSpan) {
     let stringBytes = input.divide(at: input.endPosition)
     self = unsafe stringBytes.withUnsafeBytes { buffer in
@@ -50,7 +50,7 @@ extension String {
   /// required by `count`. Any invalid UTF-8 code units are repaired by
   /// replacing with the Unicode replacement character `U+FFFD`.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingUTF8 input: inout ParserSpan, count: Int)
     throws(ParsingError)
   {
@@ -60,7 +60,7 @@ extension String {
 
   @unsafe
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   internal init(_uncheckedParsingUTF16 input: inout ParserSpan)
     throws(ParsingError)
   {
@@ -78,7 +78,7 @@ extension String {
   /// units or incomplete surrogate pairs are repaired by replacing with the
   /// Unicode replacement character `U+FFFD`.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingUTF16 input: inout ParserSpan) throws(ParsingError) {
     guard input.count.isMultiple(of: 2) else {
       throw ParsingError(status: .invalidValue, location: input.startPosition)
@@ -101,7 +101,7 @@ extension String {
   /// - Throws: A `ParsingError` if `input` doesn't have at least
   ///   `2 * codeUnitCount` bytes remaining.
   @inlinable
-  @lifetime(&input)
+  @_lifetime(&input)
   public init(parsingUTF16 input: inout ParserSpan, codeUnitCount: Int)
     throws(ParsingError)
   {

--- a/Tests/BinaryParsingTests/OptimizationTests.swift
+++ b/Tests/BinaryParsingTests/OptimizationTests.swift
@@ -24,7 +24,7 @@ private let data: [UInt8] = [
 ]
 
 struct OptimizationTests {
-  @lifetime(&input)
+  @_lifetime(&input)
   func precheckParseFour(parsing input: inout ParserSpan) throws -> Int {
     try input._checkCount(minimum: 16)
     let a = UInt32(_unchecked: (), parsingBigEndian: &input)
@@ -34,7 +34,7 @@ struct OptimizationTests {
     return Int(a + b + c + d)
   }
 
-  @lifetime(&input)
+  @_lifetime(&input)
   func parseFour(parsing input: inout ParserSpan) throws -> Int {
     let a = try UInt32(parsingBigEndian: &input)
     let b = try UInt32(parsingBigEndian: &input)


### PR DESCRIPTION
Moves from `@lifetime` to `@_lifetime` and the `LifetimeDependence` experimental feature to `Lifetimes`, eliminating a bunch of warnings in the latest compiler.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
