### PR TITLE
Add parser for LEB128 integers.

### DIFF
--- a/Sources/BinaryParsing/Parsers/Integer.swift
+++ b/Sources/BinaryParsing/Parsers/Integer.swift
@@ -696,7 +696,7 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
     }
     self = try Self(_throwing: T(truncatingIfNeeded: result))
   }
-  
+
   /// Creates an integer by parsing a little-endian base 128 (LEB128) encoded value of this type's size
   /// from the start of the given parser span.
   ///
@@ -740,7 +740,8 @@ extension FixedWidthInteger where Self: BitwiseCopyable {
         if Self.isSigned {
           let signPadding: UInt8 = (~allowedMask) & 0x7F
           guard extraBits == signPadding || extraBits == 0 else {
-            throw ParsingError(status: .invalidValue, location: input.startPosition)
+            throw ParsingError(
+              status: .invalidValue, location: input.startPosition)
           }
         } else {
           guard extraBits == 0 else {

--- a/Tests/BinaryParsingTests/IntegerParsingTests.swift
+++ b/Tests/BinaryParsingTests/IntegerParsingTests.swift
@@ -640,8 +640,8 @@ struct IntegerParsingTests {
       UInt.self, loadingFrom: UInt64.self, using: &rng)
   }
   
-  /// Some LEB128 encoders output padding bytes which are considered
-  /// valid if the number of bytes does not exceed `ceil(bitWidth / 7)`
+  // Some LEB128 encoders output padding bytes which are considered
+  // valid if the number of bytes does not exceed `ceil(bitWidth / 7)`.
   @Test(arguments: [
     ([0x80, 0x81, 0x80, 0x00], 0x80),
     ([0xFF, 0x00],             0x7F),

--- a/Tests/BinaryParsingTests/IntegerParsingTests.swift
+++ b/Tests/BinaryParsingTests/IntegerParsingTests.swift
@@ -171,6 +171,12 @@ struct IntegerParsingTests {
           }
         }
       }
+      
+      do {
+        let lebEncoded = [UInt8](encodingLEB128: number)
+        let parsed = try lebEncoded.withParserSpan { try T(parsingLEB128: &$0) }
+        #expect(parsed == number)
+      }
     }
 
     try runTest(for: .zero)
@@ -257,6 +263,12 @@ struct IntegerParsingTests {
             try T(parsing: &$0, endianness: .little, byteCount: paddedSize)
           }
         }
+      }
+      
+      do {
+        let lebEncoded = [UInt8](encodingLEB128: number)
+        let parsed = try lebEncoded.withParserSpan { try T(parsingLEB128: &$0) }
+        #expect(parsed == number)
       }
     }
 
@@ -351,6 +363,12 @@ struct IntegerParsingTests {
             try T(parsing: &$0, endianness: .little, byteCount: size)
           }
         }
+      }
+      
+      do {
+        let lebEncoded = [UInt8](encodingLEB128: number)
+        let parsed = try lebEncoded.withParserSpan { try T(parsingLEB128: &$0) }
+        #expect(parsed == number)
       }
     }
 

--- a/Tests/BinaryParsingTests/IntegerParsingTests.swift
+++ b/Tests/BinaryParsingTests/IntegerParsingTests.swift
@@ -171,7 +171,7 @@ struct IntegerParsingTests {
           }
         }
       }
-      
+
       do {
         let lebEncoded = [UInt8](encodingLEB128: number)
         let parsed = try lebEncoded.withParserSpan { try T(parsingLEB128: &$0) }
@@ -264,7 +264,7 @@ struct IntegerParsingTests {
           }
         }
       }
-      
+
       do {
         let lebEncoded = [UInt8](encodingLEB128: number)
         let parsed = try lebEncoded.withParserSpan { try T(parsingLEB128: &$0) }
@@ -364,7 +364,7 @@ struct IntegerParsingTests {
           }
         }
       }
-      
+
       do {
         let lebEncoded = [UInt8](encodingLEB128: number)
         let parsed = try lebEncoded.withParserSpan { try T(parsingLEB128: &$0) }
@@ -639,16 +639,16 @@ struct IntegerParsingTests {
     try fuzzIntegerCasting(
       UInt.self, loadingFrom: UInt64.self, using: &rng)
   }
-  
+
   // Some LEB128 encoders output padding bytes which are considered
   // valid if the number of bytes does not exceed `ceil(bitWidth / 7)`.
   @Test(arguments: [
     ([0x80, 0x81, 0x80, 0x00], 0x80),
-    ([0xFF, 0x00],             0x7F),
-    ([0xFF, 0x80, 0x00],       0x7F),
-    ([0x80, 0x81, 0x00],       0x80),
+    ([0xFF, 0x00], 0x7F),
+    ([0xFF, 0x80, 0x00], 0x7F),
+    ([0x80, 0x81, 0x00], 0x80),
     ([0x80, 0x81, 0x80, 0x00], 0x80),
-    ([0xFE, 0xFF, 0x7F],      -0x02),
+    ([0xFE, 0xFF, 0x7F], -0x02),
   ])
   func validPaddingLEB128(input: [Int], expected: Int) throws {
     let lebEncoded = input.map(UInt8.init)

--- a/Tests/BinaryParsingTests/TestingSupport.swift
+++ b/Tests/BinaryParsingTests/TestingSupport.swift
@@ -115,7 +115,7 @@ extension Array where Element == UInt8 {
       var v = value
       while true {
         var byte = UInt8(truncatingIfNeeded: v)
-        v >>= 6 // Keep the sign bit
+        v >>= 6  // Keep the sign bit
         let done = v == 0 || v == -1
         if done {
           byte &= 0x7F

--- a/Tests/BinaryParsingTests/TestingSupport.swift
+++ b/Tests/BinaryParsingTests/TestingSupport.swift
@@ -108,7 +108,7 @@ extension Array where Element == UInt8 {
       Swift.withUnsafeBytes(of: value.littleEndian, Array.init)
       + Array(repeating: paddingByte, count: paddingCount)
   }
-  
+
   init<T: FixedWidthInteger>(encodingLEB128 value: T) {
     var out: [UInt8] = []
     if T.isSigned {

--- a/Tests/BinaryParsingTests/ThrowingOperationsTests.swift
+++ b/Tests/BinaryParsingTests/ThrowingOperationsTests.swift
@@ -172,7 +172,7 @@ struct ThrowingOperationsTests {
       }
     }
   }
-  
+
   @Test(arguments: [[0xFE, 0xFF, 0xFF, 0x7F]])
   func tooManyPaddingBytesLEB128(_ input: [Int]) throws {
     let lebEncoded = input.map(UInt8.init)
@@ -180,7 +180,7 @@ struct ThrowingOperationsTests {
       try lebEncoded.withParserSpan { try Int16(parsingLEB128: &$0) }
     }
   }
-  
+
   @Test func overflowLEB128() async throws {
     func overflowTest<
       T: FixedWidthInteger & BitwiseCopyable, U: MultiByteInteger


### PR DESCRIPTION
### Description
As discussed in https://github.com/apple/swift-binary-parsing/issues/26 this pull request adds support for parsing base128 encoded little-endian integers.

### Detailed Design
An initializer has been added to `FixedWidthInteger` which is able to parse signed and unsigned LEB128 encoded integers.

```swift
public init(parsingLEB128 input: inout ParserSpan) throws(ParsingError) {
  ....
}
```

### Documentation Plan
No documentation added yet.  Options for an example parser for e.g. WASM or DWARF were considered but this would widen the scope of this PR significantly.

### Test Plan
Parsing is tested in `fuzzMultiByteInteger`,  `fuzzSingleByteInteger` and `fuzzPlatformWidthInteger` tests. An LEB128 encoder has been added to `TestSupport` to generate encoded integers in these tests.

### Source Impact
No existing APIs are affected by this.

### Checklist
- [x ] I've added at least one test that validates that my change is working, if appropriate
- [x ] I've followed the code style of the rest of the project
- [x ] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary
