### PR TITLE
Add floating point parsers

### DIFF
--- a/Sources/BinaryParsing/Parsers/FloatingPoint.swift
+++ b/Sources/BinaryParsing/Parsers/FloatingPoint.swift
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Binary Parsing open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Float16 {
+  /// Creates a `Float16` by parsing a big-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 2 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float16`.
+  @discardableResult
+  public init(parsingBigEndian input: inout ParserSpan) throws(ParsingError) {
+    let bitPattern = try UInt16(parsingBigEndian: &input)
+    self = Self(bitPattern: bitPattern)
+  }
+  
+  /// Creates a `Float16` by parsing a little-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 2 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float16`.
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+    let bitPattern = try UInt16(parsingLittleEndian: &input)
+    self = Self(bitPattern: bitPattern)
+  }
+  
+  /// Creates a `Float16` by parsing a value with the specified endianness from 
+  /// the start of the given parser span.
+  ///
+  /// - Parameters:
+  ///   - input: The `ParserSpan` to parse from. If parsing succeeds, the start
+  ///     position of `input` is moved forward by 2 bytes.
+  ///   - endianness: The endianness to use when interpreting the parsed value.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float16`.
+  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+    let bitPattern = try UInt16(parsing: &input, endianness: endianness)
+    self = Self(bitPattern: bitPattern)
+  }
+}
+
+extension Float {
+  /// Creates a `Float` by parsing a big-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 4 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float`.
+  public init(parsingBigEndian input: inout ParserSpan) throws(ParsingError) {
+    let bitPattern = try UInt32(parsingBigEndian: &input)
+    self = Self(bitPattern: bitPattern)
+  }
+  
+  /// Creates a `Float` by parsing a little-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 4 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float`.
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+    let bitPattern = try UInt32(parsingLittleEndian: &input)
+    self = Self(bitPattern: bitPattern)
+  }
+  
+  /// Creates a `Float` by parsing a value with the specified endianness from 
+  /// the start of the given parser span.
+  ///
+  /// - Parameters:
+  ///   - input: The `ParserSpan` to parse from. If parsing succeeds, the start
+  ///     position of `input` is moved forward by 4 bytes.
+  ///   - endianness: The endianness to use when interpreting the parsed value.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float`.
+  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+    let bitPattern = try UInt32(parsing: &input, endianness: endianness)
+    self = Self(bitPattern: bitPattern)
+  }
+}
+
+extension Double {
+  /// Creates a `Double` by parsing a big-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 8 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Double`.
+  public init(parsingBigEndian input: inout ParserSpan) throws(ParsingError) {
+    let bitPattern = try UInt64(parsingBigEndian: &input)
+    self = Self(bitPattern: bitPattern)
+  }
+  
+  /// Creates a `Double` by parsing a little-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 8 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Double`.
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+    let bitPattern = try UInt64(parsingLittleEndian: &input)
+    self = Self(bitPattern: bitPattern)
+  }
+
+  /// Creates a `Double` by parsing a value with the specified endianness from
+  /// the start of the given parser span.
+  ///
+  /// - Parameters:
+  ///   - input: The `ParserSpan` to parse from. If parsing succeeds, the start
+  ///     position of `input` is moved forward by 8 bytes.
+  ///   - endianness: The endianness to use when interpreting the parsed value.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Double`.
+  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+    let bitPattern = try UInt64(parsing: &input, endianness: endianness)
+    self = Self(bitPattern: bitPattern)
+  }
+}
+
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+// Local development on a non-supported platform is super fun...
+//
+//#else
+//public struct Float80: Sendable, Equatable {
+//  init(sign: FloatingPointSign, exponentBitPattern: UInt, significandBitPattern: UInt64) {}
+//}
+
+extension Float80 {
+  private init(exponentAndSign: UInt16, significandBitPattern: UInt64) {
+    let sign: FloatingPointSign = exponentAndSign >> 15 == 0 ? .plus : .minus
+    self = Self(
+      sign: sign,
+      exponentBitPattern: UInt(exponentAndSign & 0x7FFF),
+      significandBitPattern: significandBitPattern)
+  }
+  
+  /// Creates a `Float80` by parsing a big-endian value from the start of the
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 10 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float80`.
+  public init(parsingBigEndian input: inout ParserSpan) throws(ParsingError) {
+    try input._checkCount(minimum: 10)
+    self = unsafe Float80(
+      exponentAndSign: UInt16(_unchecked: (), _parsingBigEndian: &input),
+      significandBitPattern: UInt64(_unchecked: (), _parsingBigEndian: &input))
+  }
+  
+  /// Creates a `Float80` by parsing a little-endian value from the start of the 
+  /// given parser span.
+  ///
+  /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
+  ///   the start position of `input` is moved forward by 10 bytes.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float80`.
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+    // In little-endian format, significand comes first, then exponent and sign
+    try input._checkCount(minimum: 10)
+    let significandBitPattern = UInt64(_unchecked: (), _parsingLittleEndian: &input)
+    self = unsafe Float80(
+      exponentAndSign: UInt16(_unchecked: (), _parsingLittleEndian: &input),
+      significandBitPattern: significandBitPattern)
+  }
+  
+  /// Creates a `Float80` by parsing a value with the specified endianness from 
+  /// the start of the given parser span.
+  ///
+  /// - Parameters:
+  ///   - input: The `ParserSpan` to parse from. If parsing succeeds, the start
+  ///     position of `input` is moved forward by 10 bytes.
+  ///   - endianness: The endianness to use when interpreting the parsed value.
+  /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
+  ///   a `Float80`.
+  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+    if endianness.isBigEndian {
+      try self.init(parsingBigEndian: &input)
+    } else {
+      try self.init(parsingLittleEndian: &input)
+    }
+  }
+}
+
+#endif

--- a/Sources/BinaryParsing/Parsers/FloatingPoint.swift
+++ b/Sources/BinaryParsing/Parsers/FloatingPoint.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Float16 {
-  /// Creates a `Float16` by parsing a big-endian value from the start of the 
+  /// Creates a `Float16` by parsing a big-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
@@ -22,20 +22,21 @@ extension Float16 {
     let bitPattern = try UInt16(parsingBigEndian: &input)
     self = Self(bitPattern: bitPattern)
   }
-  
-  /// Creates a `Float16` by parsing a little-endian value from the start of the 
+
+  /// Creates a `Float16` by parsing a little-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
   ///   the start position of `input` is moved forward by 2 bytes.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Float16`.
-  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError)
+  {
     let bitPattern = try UInt16(parsingLittleEndian: &input)
     self = Self(bitPattern: bitPattern)
   }
-  
-  /// Creates a `Float16` by parsing a value with the specified endianness from 
+
+  /// Creates a `Float16` by parsing a value with the specified endianness from
   /// the start of the given parser span.
   ///
   /// - Parameters:
@@ -44,14 +45,16 @@ extension Float16 {
   ///   - endianness: The endianness to use when interpreting the parsed value.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Float16`.
-  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+  public init(parsing input: inout ParserSpan, endianness: Endianness)
+    throws(ParsingError)
+  {
     let bitPattern = try UInt16(parsing: &input, endianness: endianness)
     self = Self(bitPattern: bitPattern)
   }
 }
 
 extension Float {
-  /// Creates a `Float` by parsing a big-endian value from the start of the 
+  /// Creates a `Float` by parsing a big-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
@@ -62,20 +65,21 @@ extension Float {
     let bitPattern = try UInt32(parsingBigEndian: &input)
     self = Self(bitPattern: bitPattern)
   }
-  
-  /// Creates a `Float` by parsing a little-endian value from the start of the 
+
+  /// Creates a `Float` by parsing a little-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
   ///   the start position of `input` is moved forward by 4 bytes.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Float`.
-  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError)
+  {
     let bitPattern = try UInt32(parsingLittleEndian: &input)
     self = Self(bitPattern: bitPattern)
   }
-  
-  /// Creates a `Float` by parsing a value with the specified endianness from 
+
+  /// Creates a `Float` by parsing a value with the specified endianness from
   /// the start of the given parser span.
   ///
   /// - Parameters:
@@ -84,14 +88,16 @@ extension Float {
   ///   - endianness: The endianness to use when interpreting the parsed value.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Float`.
-  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+  public init(parsing input: inout ParserSpan, endianness: Endianness)
+    throws(ParsingError)
+  {
     let bitPattern = try UInt32(parsing: &input, endianness: endianness)
     self = Self(bitPattern: bitPattern)
   }
 }
 
 extension Double {
-  /// Creates a `Double` by parsing a big-endian value from the start of the 
+  /// Creates a `Double` by parsing a big-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
@@ -102,15 +108,16 @@ extension Double {
     let bitPattern = try UInt64(parsingBigEndian: &input)
     self = Self(bitPattern: bitPattern)
   }
-  
-  /// Creates a `Double` by parsing a little-endian value from the start of the 
+
+  /// Creates a `Double` by parsing a little-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
   ///   the start position of `input` is moved forward by 8 bytes.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Double`.
-  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError)
+  {
     let bitPattern = try UInt64(parsingLittleEndian: &input)
     self = Self(bitPattern: bitPattern)
   }
@@ -124,7 +131,9 @@ extension Double {
   ///   - endianness: The endianness to use when interpreting the parsed value.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Double`.
-  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+  public init(parsing input: inout ParserSpan, endianness: Endianness)
+    throws(ParsingError)
+  {
     let bitPattern = try UInt64(parsing: &input, endianness: endianness)
     self = Self(bitPattern: bitPattern)
   }
@@ -147,7 +156,7 @@ extension Float80 {
       exponentBitPattern: UInt(exponentAndSign & 0x7FFF),
       significandBitPattern: significandBitPattern)
   }
-  
+
   /// Creates a `Float80` by parsing a big-endian value from the start of the
   /// given parser span.
   ///
@@ -161,24 +170,26 @@ extension Float80 {
       exponentAndSign: UInt16(_unchecked: (), _parsingBigEndian: &input),
       significandBitPattern: UInt64(_unchecked: (), _parsingBigEndian: &input))
   }
-  
-  /// Creates a `Float80` by parsing a little-endian value from the start of the 
+
+  /// Creates a `Float80` by parsing a little-endian value from the start of the
   /// given parser span.
   ///
   /// - Parameter input: The `ParserSpan` to parse from. If parsing succeeds,
   ///   the start position of `input` is moved forward by 10 bytes.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Float80`.
-  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError) {
+  public init(parsingLittleEndian input: inout ParserSpan) throws(ParsingError)
+  {
     // In little-endian format, significand comes first, then exponent and sign
     try input._checkCount(minimum: 10)
-    let significandBitPattern = UInt64(_unchecked: (), _parsingLittleEndian: &input)
+    let significandBitPattern = UInt64(
+      _unchecked: (), _parsingLittleEndian: &input)
     self = unsafe Float80(
       exponentAndSign: UInt16(_unchecked: (), _parsingLittleEndian: &input),
       significandBitPattern: significandBitPattern)
   }
-  
-  /// Creates a `Float80` by parsing a value with the specified endianness from 
+
+  /// Creates a `Float80` by parsing a value with the specified endianness from
   /// the start of the given parser span.
   ///
   /// - Parameters:
@@ -187,7 +198,9 @@ extension Float80 {
   ///   - endianness: The endianness to use when interpreting the parsed value.
   /// - Throws: A `ParsingError` if `input` does not have enough bytes to store
   ///   a `Float80`.
-  public init(parsing input: inout ParserSpan, endianness: Endianness) throws(ParsingError) {
+  public init(parsing input: inout ParserSpan, endianness: Endianness)
+    throws(ParsingError)
+  {
     if endianness.isBigEndian {
       try self.init(parsingBigEndian: &input)
     } else {

--- a/Tests/BinaryParsingTests/FloatingPointTests.swift
+++ b/Tests/BinaryParsingTests/FloatingPointTests.swift
@@ -196,13 +196,13 @@ struct FloatingPointTests {
   #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
   @Test(arguments: Interesting.float80s)
   func testFloat80RoundTrip(_ value: Float80) throws {
-    let bytesLE = Array(littleEndian: value.bitPattern)
-    let bytesBE = Array(bigEndian: value.bitPattern)
+    let bytesLE = Array(littleEndian: value)
+    let bytesBE = Array(bigEndian: value)
 
     do {
-      let value1 = try bytesLE.withParserSpan(Double.init(parsingLittleEndian:))
+      let value1 = try bytesLE.withParserSpan(Float80.init(parsingLittleEndian:))
       let value2 = try bytesLE.withParserSpan { input in
-        try Double(parsing: &input, endianness: .little)
+        try Float80(parsing: &input, endianness: .little)
       }
 
       if value.isNaN {
@@ -219,9 +219,9 @@ struct FloatingPointTests {
     }
 
     do {
-      let value1 = try bytesBE.withParserSpan(Double.init(parsingBigEndian:))
+      let value1 = try bytesBE.withParserSpan(Float80.init(parsingBigEndian:))
       let value2 = try bytesBE.withParserSpan { input in
-        try Double(parsing: &input, endianness: .big)
+        try Float80(parsing: &input, endianness: .big)
       }
 
       if value.isNaN {
@@ -239,7 +239,7 @@ struct FloatingPointTests {
 
     // Check negative version of all values as well.
     if value.sign == .plus {
-      try testDoubleRoundTrip(-value)
+      try testFloat80RoundTrip(-value)
     }
   }
   #endif

--- a/Tests/BinaryParsingTests/FloatingPointTests.swift
+++ b/Tests/BinaryParsingTests/FloatingPointTests.swift
@@ -1,0 +1,245 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Binary Parsing open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import BinaryParsing
+import Testing
+
+enum Interesting {
+  static let float16s: [Float16] = [
+    0.0, 1.0, 1000,
+    .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
+    .greatestFiniteMagnitude, .infinity,
+    .nan, .signalingNaN
+  ]
+  
+  static let floats: [Float] = [
+    0.0, 1.0, 1000,
+    .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
+    .greatestFiniteMagnitude, .infinity,
+    .nan, .signalingNaN
+  ]
+  
+  static let doubles: [Double] = [
+    0.0, 1.0, 1000,
+    .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
+    .greatestFiniteMagnitude, .infinity,
+    .nan, .signalingNaN
+  ]
+  
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+  static let float80s: [Float80] = [
+    0.0, 1.0, 1000,
+    .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
+    .greatestFiniteMagnitude, .infinity,
+    .nan, .signalingNaN
+  ]
+#endif
+}
+
+struct FloatingPointTests {
+  @Test(arguments: Interesting.float16s)
+  func testFloat16RoundTrip(_ value: Float16) throws {
+    let bytesLE = Array(littleEndian: value.bitPattern)
+    let bytesBE = Array(bigEndian: value.bitPattern)
+    
+    do {
+      let value1 = try bytesLE.withParserSpan(Float16.init(parsingLittleEndian:))
+      let value2 = try bytesLE.withParserSpan { input in
+        try Float16(parsing: &input, endianness: .little)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    do {
+      let value1 = try bytesBE.withParserSpan(Float16.init(parsingBigEndian:))
+      let value2 = try bytesBE.withParserSpan { input in
+        try Float16(parsing: &input, endianness: .big)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    // Check negative version of all values as well.
+    if value.sign == .plus {
+      try testFloat16RoundTrip(-value)
+    }
+  }
+  
+  @Test(arguments: Interesting.floats)
+  func testFloatRoundTrip(_ value: Float) throws {
+    let bytesLE = Array(littleEndian: value.bitPattern)
+    let bytesBE = Array(bigEndian: value.bitPattern)
+    
+    do {
+      let value1 = try bytesLE.withParserSpan(Float.init(parsingLittleEndian:))
+      let value2 = try bytesLE.withParserSpan { input in
+        try Float(parsing: &input, endianness: .little)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    do {
+      let value1 = try bytesBE.withParserSpan(Float.init(parsingBigEndian:))
+      let value2 = try bytesBE.withParserSpan { input in
+        try Float(parsing: &input, endianness: .big)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    // Check negative version of all values as well.
+    if value.sign == .plus {
+      try testFloatRoundTrip(-value)
+    }
+  }
+  
+  @Test(arguments: Interesting.doubles)
+  func testDoubleRoundTrip(_ value: Double) throws {
+    let bytesLE = Array(littleEndian: value.bitPattern)
+    let bytesBE = Array(bigEndian: value.bitPattern)
+    
+    do {
+      let value1 = try bytesLE.withParserSpan(Double.init(parsingLittleEndian:))
+      let value2 = try bytesLE.withParserSpan { input in
+        try Double(parsing: &input, endianness: .little)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    do {
+      let value1 = try bytesBE.withParserSpan(Double.init(parsingBigEndian:))
+      let value2 = try bytesBE.withParserSpan { input in
+        try Double(parsing: &input, endianness: .big)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    // Check negative version of all values as well.
+    if value.sign == .plus {
+      try testDoubleRoundTrip(-value)
+    }
+  }
+  
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+  @Test(arguments: Interesting.float80s)
+  func testFloat80RoundTrip(_ value: Float80) throws {
+    let bytesLE = Array(littleEndian: value.bitPattern)
+    let bytesBE = Array(bigEndian: value.bitPattern)
+    
+    do {
+      let value1 = try bytesLE.withParserSpan(Double.init(parsingLittleEndian:))
+      let value2 = try bytesLE.withParserSpan { input in
+        try Double(parsing: &input, endianness: .little)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    do {
+      let value1 = try bytesBE.withParserSpan(Double.init(parsingBigEndian:))
+      let value2 = try bytesBE.withParserSpan { input in
+        try Double(parsing: &input, endianness: .big)
+      }
+      
+      if value.isNaN {
+        #expect(value1.isNaN)
+        #expect(value2.isNaN)
+        if value.isSignalingNaN {
+          #expect(value1.isSignalingNaN)
+          #expect(value2.isSignalingNaN)
+        }
+      } else {
+        #expect(value1 == value)
+        #expect(value2 == value)
+      }
+    }
+    
+    // Check negative version of all values as well.
+    if value.sign == .plus {
+      try testDoubleRoundTrip(-value)
+    }
+  }
+#endif
+}

--- a/Tests/BinaryParsingTests/FloatingPointTests.swift
+++ b/Tests/BinaryParsingTests/FloatingPointTests.swift
@@ -17,31 +17,31 @@ enum Interesting {
     0.0, 1.0, 1000,
     .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
     .greatestFiniteMagnitude, .infinity,
-    .nan, .signalingNaN
+    .nan, .signalingNaN,
   ]
-  
+
   static let floats: [Float] = [
     0.0, 1.0, 1000,
     .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
     .greatestFiniteMagnitude, .infinity,
-    .nan, .signalingNaN
+    .nan, .signalingNaN,
   ]
-  
+
   static let doubles: [Double] = [
     0.0, 1.0, 1000,
     .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
     .greatestFiniteMagnitude, .infinity,
-    .nan, .signalingNaN
+    .nan, .signalingNaN,
   ]
-  
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+  #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
   static let float80s: [Float80] = [
     0.0, 1.0, 1000,
     .ulpOfOne, .leastNonzeroMagnitude, .leastNormalMagnitude,
     .greatestFiniteMagnitude, .infinity,
-    .nan, .signalingNaN
+    .nan, .signalingNaN,
   ]
-#endif
+  #endif
 }
 
 struct FloatingPointTests {
@@ -49,13 +49,14 @@ struct FloatingPointTests {
   func testFloat16RoundTrip(_ value: Float16) throws {
     let bytesLE = Array(littleEndian: value.bitPattern)
     let bytesBE = Array(bigEndian: value.bitPattern)
-    
+
     do {
-      let value1 = try bytesLE.withParserSpan(Float16.init(parsingLittleEndian:))
+      let value1 = try bytesLE.withParserSpan(
+        Float16.init(parsingLittleEndian:))
       let value2 = try bytesLE.withParserSpan { input in
         try Float16(parsing: &input, endianness: .little)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -68,13 +69,13 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     do {
       let value1 = try bytesBE.withParserSpan(Float16.init(parsingBigEndian:))
       let value2 = try bytesBE.withParserSpan { input in
         try Float16(parsing: &input, endianness: .big)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -87,24 +88,24 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     // Check negative version of all values as well.
     if value.sign == .plus {
       try testFloat16RoundTrip(-value)
     }
   }
-  
+
   @Test(arguments: Interesting.floats)
   func testFloatRoundTrip(_ value: Float) throws {
     let bytesLE = Array(littleEndian: value.bitPattern)
     let bytesBE = Array(bigEndian: value.bitPattern)
-    
+
     do {
       let value1 = try bytesLE.withParserSpan(Float.init(parsingLittleEndian:))
       let value2 = try bytesLE.withParserSpan { input in
         try Float(parsing: &input, endianness: .little)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -117,13 +118,13 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     do {
       let value1 = try bytesBE.withParserSpan(Float.init(parsingBigEndian:))
       let value2 = try bytesBE.withParserSpan { input in
         try Float(parsing: &input, endianness: .big)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -136,24 +137,24 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     // Check negative version of all values as well.
     if value.sign == .plus {
       try testFloatRoundTrip(-value)
     }
   }
-  
+
   @Test(arguments: Interesting.doubles)
   func testDoubleRoundTrip(_ value: Double) throws {
     let bytesLE = Array(littleEndian: value.bitPattern)
     let bytesBE = Array(bigEndian: value.bitPattern)
-    
+
     do {
       let value1 = try bytesLE.withParserSpan(Double.init(parsingLittleEndian:))
       let value2 = try bytesLE.withParserSpan { input in
         try Double(parsing: &input, endianness: .little)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -166,13 +167,13 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     do {
       let value1 = try bytesBE.withParserSpan(Double.init(parsingBigEndian:))
       let value2 = try bytesBE.withParserSpan { input in
         try Double(parsing: &input, endianness: .big)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -185,25 +186,25 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     // Check negative version of all values as well.
     if value.sign == .plus {
       try testDoubleRoundTrip(-value)
     }
   }
-  
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+  #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
   @Test(arguments: Interesting.float80s)
   func testFloat80RoundTrip(_ value: Float80) throws {
     let bytesLE = Array(littleEndian: value.bitPattern)
     let bytesBE = Array(bigEndian: value.bitPattern)
-    
+
     do {
       let value1 = try bytesLE.withParserSpan(Double.init(parsingLittleEndian:))
       let value2 = try bytesLE.withParserSpan { input in
         try Double(parsing: &input, endianness: .little)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -216,13 +217,13 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     do {
       let value1 = try bytesBE.withParserSpan(Double.init(parsingBigEndian:))
       let value2 = try bytesBE.withParserSpan { input in
         try Double(parsing: &input, endianness: .big)
       }
-      
+
       if value.isNaN {
         #expect(value1.isNaN)
         #expect(value2.isNaN)
@@ -235,11 +236,11 @@ struct FloatingPointTests {
         #expect(value2 == value)
       }
     }
-    
+
     // Check negative version of all values as well.
     if value.sign == .plus {
       try testDoubleRoundTrip(-value)
     }
   }
-#endif
+  #endif
 }

--- a/Tests/BinaryParsingTests/FloatingPointTests.swift
+++ b/Tests/BinaryParsingTests/FloatingPointTests.swift
@@ -34,6 +34,14 @@ enum Interesting {
     .nan, .signalingNaN,
   ]
 
+  static let float80OneLE: [UInt8] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0xff, 0x3f,
+  ]
+
+  static let float80OneBE: [UInt8] = [
+    0x3f, 0xff, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
   #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
   static let float80s: [Float80] = [
     0.0, 1.0, 1000,
@@ -182,7 +190,7 @@ struct FloatingPointTests {
           #expect(value2.isSignalingNaN)
         }
       } else {
-        #expect(value1 == value)
+        #expect(value1 == value, "\(1)")
         #expect(value2 == value)
       }
     }
@@ -194,13 +202,25 @@ struct FloatingPointTests {
   }
 
   #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+  @Test
+  func staticFloat80() throws {
+    let leValue = try Interesting.float80OneLE.withParserSpan(
+      Float80.init(parsingLittleEndian:))
+    let beValue = try Interesting.float80OneBE.withParserSpan(
+      Float80.init(parsingBigEndian:))
+
+    #expect(leValue == 1.0)
+    #expect(beValue == 1.0)
+  }
+
   @Test(arguments: Interesting.float80s)
   func testFloat80RoundTrip(_ value: Float80) throws {
     let bytesLE = Array(littleEndian: value)
     let bytesBE = Array(bigEndian: value)
 
     do {
-      let value1 = try bytesLE.withParserSpan(Float80.init(parsingLittleEndian:))
+      let value1 = try bytesLE.withParserSpan(
+        Float80.init(parsingLittleEndian:))
       let value2 = try bytesLE.withParserSpan { input in
         try Float80(parsing: &input, endianness: .little)
       }

--- a/Tests/BinaryParsingTests/TestingSupport.swift
+++ b/Tests/BinaryParsingTests/TestingSupport.swift
@@ -137,6 +137,30 @@ extension Array where Element == UInt8 {
     }
     self = out
   }
+  
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+  init(littleEndian value: Float80) {
+    self = []
+    Swift.withUnsafeBytes(of: value.significandBitPattern.littleEndian) { bytes in
+      self.append(contentsOf: bytes)
+    }
+    let signAndExponent = value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
+    Swift.withUnsafeBytes(of: signAndExponent.littleEndian) { bytes in
+      self.append(contentsOf: bytes)
+    }
+  }
+
+  init(bigEndian value: Float80) {
+    self = []
+    let signAndExponent = value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
+    Swift.withUnsafeBytes(of: signAndExponent.bigEndian) { bytes in
+      self.append(contentsOf: bytes)
+    }
+    Swift.withUnsafeBytes(of: value.significandBitPattern.bigEndian) { bytes in
+      self.append(contentsOf: bytes)
+    }
+  }
+#endif
 }
 
 /// A seeded random number generator type.

--- a/Tests/BinaryParsingTests/TestingSupport.swift
+++ b/Tests/BinaryParsingTests/TestingSupport.swift
@@ -145,8 +145,9 @@ extension Array where Element == UInt8 {
       bytes in
       self.append(contentsOf: bytes)
     }
-    let signAndExponent =
-      value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
+    let signAndExponent = UInt16(
+      truncatingIfNeeded:
+        value.exponentBitPattern | ((value.sign == .minus ? 1 : 0) << 15))
     Swift.withUnsafeBytes(of: signAndExponent.littleEndian) { bytes in
       self.append(contentsOf: bytes)
     }
@@ -154,8 +155,9 @@ extension Array where Element == UInt8 {
 
   init(bigEndian value: Float80) {
     self = []
-    let signAndExponent =
-      value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
+    let signAndExponent = UInt16(
+      truncatingIfNeeded:
+        value.exponentBitPattern | ((value.sign == .minus ? 1 : 0) << 15))
     Swift.withUnsafeBytes(of: signAndExponent.bigEndian) { bytes in
       self.append(contentsOf: bytes)
     }

--- a/Tests/BinaryParsingTests/TestingSupport.swift
+++ b/Tests/BinaryParsingTests/TestingSupport.swift
@@ -137,14 +137,16 @@ extension Array where Element == UInt8 {
     }
     self = out
   }
-  
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+  #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
   init(littleEndian value: Float80) {
     self = []
-    Swift.withUnsafeBytes(of: value.significandBitPattern.littleEndian) { bytes in
+    Swift.withUnsafeBytes(of: value.significandBitPattern.littleEndian) {
+      bytes in
       self.append(contentsOf: bytes)
     }
-    let signAndExponent = value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
+    let signAndExponent =
+      value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
     Swift.withUnsafeBytes(of: signAndExponent.littleEndian) { bytes in
       self.append(contentsOf: bytes)
     }
@@ -152,7 +154,8 @@ extension Array where Element == UInt8 {
 
   init(bigEndian value: Float80) {
     self = []
-    let signAndExponent = value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
+    let signAndExponent =
+      value.exponentBitPattern | (value.sign == .minus ? 1 : 0 << 31)
     Swift.withUnsafeBytes(of: signAndExponent.bigEndian) { bytes in
       self.append(contentsOf: bytes)
     }
@@ -160,7 +163,7 @@ extension Array where Element == UInt8 {
       self.append(contentsOf: bytes)
     }
   }
-#endif
+  #endif
 }
 
 /// A seeded random number generator type.


### PR DESCRIPTION
Adds parsers for the standard library floating point types with endianness specifiers. Resolves #25.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've run `Scripts/format.sh` to correctly format my change
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
