### PR TITLE
Don't use the prebuilt swift-syntax binary

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
       format_check_container_image: swiftlang/swift:nightly-6.2-jammy
       shell_check_enabled: true
       yamllint_check_enabled: true
-      api_breakage_check_enabled: true
+      api_breakage_check_enabled: false  # doesn't allow skipping prebuilt swift-syntax binary
       api_breakage_check_container_image: swiftlang/swift:nightly-6.2-jammy
       docs_check_enabled: false  # nightly container has issues installing yq
       docs_check_container_image: swiftlang/swift:nightly-6.2-jammy


### PR DESCRIPTION
The [current version][url] of the binary might be causing compilation issues. This change skips it for now.

[url]: https://download.swift.org/prebuilts/swift-syntax/600.0.1/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-06-a-MacroSupport-ubuntu_jammy_x86_64.tar