### PR TITLE
Prefer FoundationEssentials over Foundation for the Data bridges

### DIFF
--- a/Sources/BinaryParsing/Parser Types/ParserSource.swift
+++ b/Sources/BinaryParsing/Parser Types/ParserSource.swift
@@ -9,7 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded && canImport(Foundation)
+#if !$Embedded && canImport(FoundationEssentials)
+public import FoundationEssentials
+#elseif !$Embedded && canImport(Foundation)
 public import Foundation
 #endif
 
@@ -65,8 +67,8 @@ extension RandomAccessCollection<UInt8> {
   public func withParserSpanIfAvailable<T>(
     _ body: (inout ParserSpan) throws(ThrownParsingError) -> T
   ) throws(ThrownParsingError) -> T? {
-    #if !$Embedded && canImport(Foundation)
-    if let data = self as? Foundation.Data {
+    #if !$Embedded && (canImport(FoundationEssentials) || canImport(Foundation))
+    if let data = self as? Data {
       let result = unsafe data.withUnsafeBytes { buffer in
         var span = unsafe ParserSpan(_unsafeBytes: buffer)
         return Result<T, ThrownParsingError> { try body(&span) }
@@ -138,7 +140,7 @@ extension ParserSpanProvider {
   }
 }
 
-#if !$Embedded && canImport(Foundation)
+#if !$Embedded && (canImport(FoundationEssentials) || canImport(Foundation))
 extension Data: ParserSpanProvider {
   @inlinable
   public func withParserSpan<T, E>(

--- a/Sources/BinaryParsing/Parsers/Data.swift
+++ b/Sources/BinaryParsing/Parsers/Data.swift
@@ -9,9 +9,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded && canImport(Foundation)
+#if !$Embedded && canImport(FoundationEssentials)
+public import FoundationEssentials
+#elseif !$Embedded && canImport(Foundation)
 public import Foundation
+#endif
 
+#if !$Embedded && (canImport(FoundationEssentials) || canImport(Foundation))
 extension Data {
   /// Creates a new data instance by copying the remaining bytes from the
   /// given parser span.


### PR DESCRIPTION
Note: apologies for the Claude verbosity here, it is a simple fix though so should be easy to review. @lhoward.

## Motivation

The optional `Data` conveniences in `ParserSource.swift` and `Parsers/Data.swift` use `public import Foundation`, guarded only on `canImport(Foundation)`. Two consequences on non-Darwin (Linux) platforms:

1. Because these are **`public` (re-exported) imports**, *every* downstream consumer of `BinaryParsing` inherits a link dependency on full `Foundation` — even modules that never touch `Data`. The autolink propagates transitively.
2. Full `Foundation` on Linux pulls in `FoundationInternationalization` and the **ICU data library** (`_FoundationICU`, tens of MB), even though the only symbol used from Foundation here is **`Data`**, which is available in `FoundationEssentials`.

For size-sensitive / embedded-adjacent Linux deployments this drags the entire ICU blob into the link closure of any executable that uses `BinaryParsing` but not full Foundation. (Found while shrinking a Swift networking daemon for a 64 MB target — `BinaryParsing` was the sole remaining anchor forcing `libFoundation` + ICU into an otherwise `FoundationEssentials`-only binary.)

## Change

In both files, prefer `FoundationEssentials` when available, falling back to full `Foundation`:

```swift
#if !$Embedded && canImport(FoundationEssentials)
public import FoundationEssentials
#elseif !$Embedded && canImport(Foundation)
public import Foundation
#endif
```

- The `canImport(Foundation)` guards around the `Data` extensions are widened to `(canImport(FoundationEssentials) || canImport(Foundation))`.
- `Foundation.Data` is de-qualified to `Data` so it resolves from whichever module was imported.
- `$Embedded` handling is unchanged.

## Effect

No API change — the `Data` initializers (`init(parsingRemainingBytes:)`, `init(parsing:byteCount:)`) and the `Data: ParserSpanProvider` conformance are identical. On Linux this removes `libFoundation`, `libFoundationInternationalization`, and the ICU data library from the transitive link closure for consumers that don't otherwise use full Foundation. Verified end-to-end: a dynamically-linked executable depending on `BinaryParsing` dropped from needing `libFoundation` + `libFoundationInternationalization` + `_FoundationICU` to needing only `libFoundationEssentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)