### PR TITLE
Update dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,14 +24,14 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+      url: "https://github.com/apple/swift-argument-parser", from: "1.8.0"),
     .package(
-      url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
+      url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
     .package(
       url: "https://github.com/pointfreeco/swift-macro-testing.git",
-      from: "0.6.4"),
+      from: "0.6.5"),
     .package(
-      url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+      url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.5.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Bumps the minimum versions of the package's dependencies:

- `swift-syntax`: 602.0.0 → 603.0.0 (currently resolves to 603.0.2)
- `swift-argument-parser`: 1.3.0 → 1.8.0 (currently resolves to 1.8.2)
- `swift-macro-testing`: 0.6.4 → 0.6.5
- `swift-docc-plugin`: 1.0.0 → 1.5.0

`swift build` succeeds with the updated dependencies.

Note: `swift test` currently fails to build on Swift 6.3.3, but this is pre-existing and unrelated to this change — `swift-snapshot-testing` 1.19.3 (pulled in transitively by `swift-macro-testing`) doesn't compile against the toolchain's `swift-testing` `Attachment` API. The same failure occurs on `main` without this change, and 1.19.3 is the latest release.