### PR TITLE
Fix integer overflow in `_checkCount(minimum:)`

### DIFF
--- a/Sources/BinaryParsing/Parsers/Integer.swift
+++ b/Sources/BinaryParsing/Parsers/Integer.swift
@@ -12,8 +12,7 @@
 extension ParserSpan {
   @inlinable
   public func _checkCount(minimum: Int) throws(ParsingError) {
-    let requiredUpper = _lowerBound &+ minimum
-    guard requiredUpper <= _upperBound else {
+    guard count >= minimum else {
       throw ParsingError(
         status: .insufficientData,
         location: startPosition)

--- a/Tests/BinaryParsingTests/IntegerParsingTests.swift
+++ b/Tests/BinaryParsingTests/IntegerParsingTests.swift
@@ -655,4 +655,15 @@ struct IntegerParsingTests {
     let result = try lebEncoded.withParserSpan { try Int(parsingLEB128: &$0) }
     #expect(result == expected)
   }
+
+  @Test
+  func checkCountDoesNotOverflow() throws {
+    try bigEndianOnes.withParserSpanIfAvailable { span in
+      // Consume some bytes so that `startPosition` is nonzero.
+      _ = try UInt32(parsingBigEndian: &span)
+      #expect(throws: ParsingError.self) {
+        try span._checkCount(minimum: .max)
+      }
+    }
+  }
 }


### PR DESCRIPTION
The current implementation adds the given `minimum` and `_lowerBound`, which can wrap around if the minimum is very large, incorrectly passing the size check. This change uses `count` instead, which is always the real upper bound for `minimum`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've run `Scripts/format.sh` to correctly format my change
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
