### PR TITLE
Fix undefined behavior in UTF-16 parsing from unaligned buffers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     .package(
-      url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
+      url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
     .package(
       url: "https://github.com/pointfreeco/swift-macro-testing.git",
       from: "0.6.4"),

--- a/Sources/BinaryParsing/Parsers/String.swift
+++ b/Sources/BinaryParsing/Parsers/String.swift
@@ -60,10 +60,18 @@ extension String {
   internal init(_uncheckedParsingUTF16 input: inout ParserSpan)
     throws(ParsingError)
   {
+    assert(input.count.isMultiple(of: 2))
     let stringBytes = input.divide(at: input.endPosition)
     self = unsafe stringBytes.withUnsafeBytes { buffer in
-      let utf16Buffer = unsafe buffer.assumingMemoryBound(to: UInt16.self)
-      return unsafe String(decoding: utf16Buffer, as: UTF16.self)
+      guard let base = buffer.baseAddress else { return "" }
+      if base._isAligned(for: UInt16.self) {
+        let utf16Buffer = unsafe buffer.assumingMemoryBound(to: UInt16.self)
+        return unsafe String(decoding: utf16Buffer, as: UTF16.self)
+      } else {
+        let utf16Buffer = unsafe _UnalignedUnsafeBufferPointer<UInt16>(
+          _base: base, _count: buffer.count / 2)
+        return unsafe String(decoding: utf16Buffer, as: UTF16.self)
+      }
     }
   }
 
@@ -102,5 +110,50 @@ extension String {
     var slice = try input._divide(
       atByteOffset: codeUnitCount.multipliedThrowingOnOverflow(by: 2))
     unsafe try self.init(_uncheckedParsingUTF16: &slice)
+  }
+}
+
+// MARK: - Unaligned buffer pointer
+
+extension UnsafeRawPointer {
+  @export(implementation)
+  @safe
+  func _isAligned<T>(for: T.Type) -> Bool {
+    Int(bitPattern: self) & (MemoryLayout<T>.alignment - 1) == 0
+  }
+}
+
+@unsafe
+@usableFromInline
+struct _UnalignedUnsafeBufferPointer<T: BitwiseCopyable> {
+  @usableFromInline
+  typealias Element = T
+  @usableFromInline
+  typealias Index = Int
+
+  @usableFromInline
+  var _base: UnsafeRawPointer
+  @usableFromInline
+  @safe var _count: Int
+
+  @export(implementation)
+  init(_base: UnsafeRawPointer, _count: Int) {
+    unsafe self._base = _base
+    self._count = _count
+  }
+}
+
+extension _UnalignedUnsafeBufferPointer: @unsafe RandomAccessCollection {
+  @export(implementation)
+  var startIndex: Int { 0 }
+  @export(implementation)
+  var endIndex: Int { _count }
+
+  @export(implementation)
+  subscript(position: Int) -> T {
+    get {
+      unsafe _base.loadUnaligned(
+        fromByteOffset: position * MemoryLayout<T>.stride, as: T.self)
+    }
   }
 }

--- a/Sources/BinaryParsing/Parsers/String.swift
+++ b/Sources/BinaryParsing/Parsers/String.swift
@@ -116,7 +116,7 @@ extension String {
 // MARK: - Unaligned buffer pointer
 
 extension UnsafeRawPointer {
-  @export(implementation)
+  @_alwaysEmitIntoClient
   @safe
   func _isAligned<T>(for: T.Type) -> Bool {
     Int(bitPattern: self) & (MemoryLayout<T>.alignment - 1) == 0
@@ -136,7 +136,7 @@ struct _UnalignedUnsafeBufferPointer<T: BitwiseCopyable> {
   @usableFromInline
   @safe var _count: Int
 
-  @export(implementation)
+  @_alwaysEmitIntoClient
   init(_base: UnsafeRawPointer, _count: Int) {
     unsafe self._base = _base
     self._count = _count
@@ -144,12 +144,12 @@ struct _UnalignedUnsafeBufferPointer<T: BitwiseCopyable> {
 }
 
 extension _UnalignedUnsafeBufferPointer: @unsafe RandomAccessCollection {
-  @export(implementation)
+  @_alwaysEmitIntoClient
   var startIndex: Int { 0 }
-  @export(implementation)
+  @_alwaysEmitIntoClient
   var endIndex: Int { _count }
 
-  @export(implementation)
+  @_alwaysEmitIntoClient
   subscript(position: Int) -> T {
     get {
       unsafe _base.loadUnaligned(

--- a/Tests/BinaryParsingTests/StringParsingTests.swift
+++ b/Tests/BinaryParsingTests/StringParsingTests.swift
@@ -213,6 +213,20 @@ struct StringParsingTests {
   }
 
   @Test
+  func parseUTF16Unaligned() throws {
+    // Prepend a single byte so that the UTF-16 code units that follow start
+    // at an odd offset within the backing buffer, forcing a misaligned load.
+    let buffer: [UInt8] = [0xAA] + testStringNonASCII.utf16Buffer
+
+    try buffer.withParserSpan { span in
+      _ = try UInt8(parsing: &span)
+      let str = try String(parsingUTF16: &span)
+      #expect(str == testStringNonASCII)
+      #expect(span.count == 0)
+    }
+  }
+
+  @Test
   func testMultipleOperationsOnSameBuffer() throws {
     let combinedString = "\(testString)\0\(testStringNonASCII)"
 


### PR DESCRIPTION
`URBP.assumingMemoryBound(to:)` requires that the buffer is `UInt16`- aligned, which doesn't necessarily hold when reading a binary file. This change adds an `_UnalignedUnsafeBufferPointer` and uses it when the memory to be parsed as a UTF16 string is out of alignment with `UInt16`.

This will go through a slow path in UTF16 -> UTF8 string initialization (since the new unaligned buffer isn't one of the always-specialized types) so we should benchmark this change.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've run `Scripts/format.sh` to correctly format my change
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-binary-parsing/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
